### PR TITLE
Resolve extra semi-colon error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ MARCH ?= $(shell uname -m)
 
 ARCH_SRCS := $(wildcard posix/*.c)
 ARCH = POSIX
-SDK = 
+SDK =
 
 ifeq ($(OS),Linux)
 	ARCH = LINUX
@@ -75,11 +75,11 @@ else ifneq (,$(findstring 10.8,$(OS_VERSION)))
 	CRASH_REPORT = third_party/CrashReport_Mountain_Lion.o
 else
 	SDK_NAME = "macosx"
-	CRASH_REPORT = 
+	CRASH_REPORT =
 endif
 	CC = $(shell xcrun --sdk $(SDK_NAME) --find cc)
 	SDK = $(shell xcrun --sdk $(SDK_NAME) --show-sdk-path)
-	CFLAGS = -arch x86_64 -O3 -g -ggdb -std=c99 -isysroot $(SDK) -I. -I~/.homebrew/include -I/usr/include \
+	CFLAGS = -arch x86_64 -O3 -g -ggdb -std=c99 -isysroot $(SDK) -I. \
 	    -x objective-c \
 		-D_GNU_SOURCE \
 		-pedantic \
@@ -91,7 +91,7 @@ endif
 		-F$(SDK)/System/Library/Frameworks -F$(SDK)/System/Library/PrivateFrameworks \
 		-framework Foundation -framework ApplicationServices -framework Symbolication \
 		-framework CoreServices -framework CrashReporterSupport -framework CoreFoundation \
-		-framework CommerceKit -lm -L/usr/include -L$(shell echo ~)/.homebrew/lib
+		-framework CommerceKit -lm
 	ARCH_SRCS = $(wildcard mac/*.c)
 	MIG_OUTPUT = mach_exc.h mach_excUser.c mach_excServer.h mach_excServer.c
 	MIG_OBJECTS = mach_excUser.o mach_excServer.o


### PR DESCRIPTION
When building on OSX 10.10.3 I encountered the following error.
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -c -arch x86_64 -O3 -g -ggdb -std=c99 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -I. -I/usr/include -x objective-c -D_GNU_SOURCE -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wreturn-type -Wpointer-arith -Wno-gnu-case-range -Wno-gnu-designator -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-attributes -D_HF_ARCH_DARWIN -o mac/arch.o mac/arch.c
In file included from mac/arch.c:49:
/usr/include/servers/bootstrap.h:20:14: error: extra ';' outside of a function [-Werror,-Wextra-semi]
__BEGIN_DECLS;
             ^
/usr/include/servers/bootstrap.h:112:12: error: extra ';' outside of a function [-Werror,-Wextra-semi]
__END_DECLS;
           ^
2 errors generated.
make: *** [mac/arch.o] Error 1
```

Removing `-I/usr/include` seemed to resolve the issue while still compiling correctly.

I also removed `-I~/.homebrew/include` as it appears to be unnecessary.