### PR TITLE
Android support + minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.o
+*.so
+honggfuzz
+*.dSYM
+mach_exc.h
+mach_excUser.c
+mach_excServer.h
+mach_excServer.c
+libs
+obj

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifeq ($(OS),Linux)
 		# Support for popcnt (used in linux/perf.c)
 		CFLAGS += -msse4.2
 	endif	# MARCH
-endif	# OS
+endif	# OS Linux
 
 ifeq ($(OS),Darwin)
 	OS_VERSION = $(shell sw_vers -productVersion)
@@ -96,7 +96,7 @@ endif
 	MIG_OUTPUT = mach_exc.h mach_excUser.c mach_excServer.h mach_excServer.c
 	MIG_OBJECTS = mach_excUser.o mach_excServer.o
 	ARCH = DARWIN
-endif
+endif	# OS Darwin
 
 SRCS += $(ARCH_SRCS)
 CFLAGS += -D_HF_ARCH_${ARCH}
@@ -131,13 +131,17 @@ $(MIG_OBJECTS): $(MIG_OUTPUT)
 	$(CC) -c $(CFLAGS) mach_excServer.c
 
 clean:
-	$(RM) core $(OBJS) $(BIN) $(MIG_OUTPUT) $(MIG_OBJECTS) $(INTERCEPTOR_LIBS)
+	$(RM) -r core $(OBJS) $(BIN) $(MIG_OUTPUT) $(MIG_OBJECTS) $(INTERCEPTOR_LIBS) obj libs
 
 indent:
 	indent -linux -l100 -lc100 -nut -i4 -sob -c33 -cp33 *.c *.h */*.c */*.h; rm -f *~ */*~
 
 depend:
 	makedepend -Y. -Y* -- $(SRCS)
+	
+.PHONY:android
+android:
+	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./android/Android.mk APP_PLATFORM=android-21
 
 # DO NOT DELETE
 

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -1,0 +1,33 @@
+#   honggfuzz - Android makefile
+#   -----------------------------------------
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+LOCAL_PATH := $(abspath $(call my-dir)/..)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := honggfuzz
+LOCAL_SRC_FILES := honggfuzz.c log.c files.c fuzz.c report.c mangle.c util.c
+LOCAL_CFLAGS := -std=c11 -I. \
+    -D_GNU_SOURCE \
+    -Wall -Wextra -Wno-initializer-overrides -Wno-override-init -Wno-unknown-warning-option -Werror \
+    -funroll-loops -O2
+LOCAL_LDFLAGS := -lm
+
+ARCH_SRCS := $(wildcard posix/*.c)
+ARCH = POSIX
+
+LOCAL_SRC_FILES += $(ARCH_SRCS)
+LOCAL_CFLAGS += -D_HF_ARCH_${ARCH}
+
+include $(BUILD_EXECUTABLE)

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -44,7 +44,7 @@
 static bool checkFor_FILE_PLACEHOLDER(char **args)
 {
     for (int x = 0; args[x]; x++) {
-        if (!strcmp(args[x], _HF_FILE_PLACEHOLDER))
+        if (strstr(args[x], _HF_FILE_PLACEHOLDER))
             return true;
     }
     return false;

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -88,12 +88,16 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
     }
 #define ARGS_MAX 512
     char *args[ARGS_MAX + 2];
-
+    char argData[PATH_MAX] = { 0 };
     int x;
 
     for (x = 0; x < ARGS_MAX && hfuzz->cmdline[x]; x++) {
         if (!hfuzz->fuzzStdin && strcmp(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER) == 0) {
             args[x] = fileName;
+        } else if (!hfuzz->fuzzStdin && strstr(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER)) {
+            const char *off = strstr(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER);
+            snprintf(argData, PATH_MAX, "%.*s%s", (int)(off - hfuzz->cmdline[x]), hfuzz->cmdline[x], fileName);
+            args[x] = argData;
         } else {
             args[x] = hfuzz->cmdline[x];
         }

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -233,12 +233,16 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
 {
 #define ARGS_MAX 512
     char *args[ARGS_MAX + 2];
-
+    char argData[PATH_MAX] = { 0 };
     int x;
 
     for (x = 0; x < ARGS_MAX && hfuzz->cmdline[x]; x++) {
         if (!hfuzz->fuzzStdin && strcmp(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER) == 0) {
             args[x] = fileName;
+        } else if (!hfuzz->fuzzStdin && strstr(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER)) {
+            const char *off = strstr(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER);
+            snprintf(argData, PATH_MAX, "%.*s%s", (int)(off - hfuzz->cmdline[x]), hfuzz->cmdline[x], fileName);
+            args[x] = argData;
         } else {
             args[x] = hfuzz->cmdline[x];
         }

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -41,6 +41,12 @@
 #include "log.h"
 #include "util.h"
 
+#ifdef __ANDROID__
+#ifndef WIFCONTINUED
+#define WIFCONTINUED(x) WEXITSTATUS(0)
+#endif
+#endif
+
 /*  *INDENT-OFF* */
 struct {
     bool important;
@@ -122,12 +128,16 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
 {
 #define ARGS_MAX 512
     char *args[ARGS_MAX + 2];
-
+    char argData[PATH_MAX] = { 0 };
     int x;
 
     for (x = 0; x < ARGS_MAX && hfuzz->cmdline[x]; x++) {
         if (!hfuzz->fuzzStdin && strcmp(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER) == 0) {
             args[x] = fileName;
+        } else if (!hfuzz->fuzzStdin && strstr(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER)) {
+            const char *off = strstr(hfuzz->cmdline[x], _HF_FILE_PLACEHOLDER);
+            snprintf(argData, PATH_MAX, "%.*s%s", (int)(off - hfuzz->cmdline[x]), hfuzz->cmdline[x], fileName);
+            args[x] = argData;
         } else {
             args[x] = hfuzz->cmdline[x];
         }


### PR DESCRIPTION
* Add Android API 21 support (make android) using POSIX / SIGNAL arch
* Add support for targets with args of type "arg=___FILE___"
* Add .gitignore

Have tested a few Android ARM targets fuzzing with Lollipop (API 21) and haven't spotted any issues. ptrace and perf counters (ARM & x86) is also doable in Android, although that requires a lot more tweaking and testing due to incompatibilities with bionic ptrace APIs.