### PR TITLE
Fix android x86_64 libunwind

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -31,7 +31,6 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86_64))
     ARCH_ABI := x86_64
     UNW_ARCH := x86_64
-    $(error $(APP_ABI) Android not supported with ptrace API (issues with libunwind))
   else
     $(error Unsuported / Unknown APP_API '$(APP_ABI)')
   endif
@@ -92,7 +91,7 @@ LOCAL_LDFLAGS := -lm
 
 ifeq ($(ANDROID_WITH_PTRACE),true)
   LOCAL_C_INCLUDES := third_party/android/libunwind/include third_party/android/capstone/include
-  LOCAL_STATIC_LIBRARIES := libunwind libunwind-arch libunwind-ptrace libunwind-dwarf-generic libcapstone
+  LOCAL_STATIC_LIBRARIES := libunwind-arch libunwind libunwind-ptrace libunwind-dwarf-generic libcapstone
   LOCAL_CFLAGS += -D__HF_USE_CAPSTONE__
   ARCH_SRCS := linux/arch.c linux/ptrace_utils.c linux/perf.c linux/unwind.c
   ARCH := LINUX

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -24,7 +24,7 @@ It has been tested under the following CPU architectures:
 | **armeabi-v7a** | ptrace() API & POSIX signal interface |
 | **arm64-v8a** | ptrace() API & POSIX signal interface `*`|
 | **x86** | ptrace() API & POSIX signal interface |
-| **x86_64** | POSIX signal interface (ptrace API & capstone work, although libunwind does not) |
+| **x86_64** | ptrace() API & POSIX signal interface |
 
 _`*`) libunwind fails to extract frames if fuzzing target is 32bit. Prefer a 32bit build for such targets._
 

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -24,7 +24,7 @@ It has been tested under the following CPU architectures:
 | **armeabi-v7a** | ptrace() API & POSIX signal interface |
 | **arm64-v8a** | ptrace() API & POSIX signal interface `*`|
 | **x86** | ptrace() API & POSIX signal interface |
-| **x86_64** | POSIX signal interface (ptrace API & capstone work, although libunwind not) |
+| **x86_64** | ptrace() API & POSIX signal interface |
 
 _`*`) libunwind fails to extract frames if fuzzing target is 32bit. Prefer a 32bit build for such targets._
 

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -75,7 +75,7 @@ static void usage(bool exit_success)
            " [" AB "-a val" AC "] : address limit (from si.si_addr) below which crashes\n"
            "            are not reported, (default: '" AB "0" AC "' [suggested: 65535])\n"
            " [" AB "-n val" AC "] : number of concurrent fuzzing threads, (default: '" AB "2" AC "')\n"
-           " [" AB "-N val" AC "] : number of fuzzing mutations, (default: '" AB "0" AC "' [infinte])\n"
+           " [" AB "-N val" AC "] : number of fuzzing mutations, (default: '" AB "0" AC "' [infinite])\n"
            " [" AB "-l val" AC "] : per process memory limit in MiB, (default: '" AB "0" AC "' [no limit])\n"
            " [" AB "-R val" AC "] : write report to this file, (default: '" AB _HF_REPORT_FILE AC "')\n"
            " [" AB "-F val" AC "] : Maximal size of files created by the fuzzer (default '" AB "1048576" AC "')\n"

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -134,7 +134,7 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
             .rlim_max = hfuzz->asLimit * 1024UL * 1024UL,
         };
         if (setrlimit(RLIMIT_AS, &rl) == -1) {
-            LOGMSG_P(l_DEBUG, "Couldn't encforce the RLIMIT_AS resource limit, ignoring");
+            LOGMSG_P(l_DEBUG, "Couldn't enforce the RLIMIT_AS resource limit, ignoring");
         }
     }
 
@@ -218,7 +218,7 @@ static bool arch_setTimer(timer_t * timerid)
         .sa_restorer = NULL,
     };
     if (sigaction(SIGALRM, &sa, NULL) == -1) {
-        LOGMSG_P(l_ERROR, "sigaciton(SIGALRM) failed");
+        LOGMSG_P(l_ERROR, "sigaction(SIGALRM) failed");
         return false;
     }
 

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -338,7 +338,7 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
         rl.rlim_cur = hfuzz->asLimit * 1024UL * 1024UL;
         rl.rlim_max = hfuzz->asLimit * 1024UL * 1024UL;
         if (setrlimit(RLIMIT_AS, &rl) == -1) {
-            LOGMSG_P(l_DEBUG, "Couldn't encforce the RLIMIT_AS resource limit, ignoring");
+            LOGMSG_P(l_DEBUG, "Couldn't enforce the RLIMIT_AS resource limit, ignoring");
         }
     }
 
@@ -383,7 +383,7 @@ static void arch_checkTimeLimit(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 {
     /*
-     * First check manually if we have expired childs
+     * First check manually if we have expired children
      */
     arch_checkTimeLimit(hfuzz, fuzzer);
 

--- a/mangle.c
+++ b/mangle.c
@@ -106,7 +106,7 @@ static void mangle_Magic(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_
         const uint8_t val[8];
         const size_t size;
     } mangleMagicVals[] = {
-        /* 1B - No endianess */
+        /* 1B - No endianness */
         { "\x00\x00\x00\x00\x00\x00\x00\x00", 1},
         { "\x01\x00\x00\x00\x00\x00\x00\x00", 1},
         { "\x02\x00\x00\x00\x00\x00\x00\x00", 1},

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -202,7 +202,7 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
         rl.rlim_cur = hfuzz->asLimit * 1024UL * 1024UL;
         rl.rlim_max = hfuzz->asLimit * 1024UL * 1024UL;
         if (setrlimit(RLIMIT_AS, &rl) == -1) {
-            LOGMSG_P(l_DEBUG, "Couldn't encforce the RLIMIT_AS resource limit, ignoring");
+            LOGMSG_P(l_DEBUG, "Couldn't enforce the RLIMIT_AS resource limit, ignoring");
         }
     }
 

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -55,7 +55,7 @@ LC_LDFLAGS="-static"
 
 # For debugging
 # Remember to export UNW_DEBUG_LEVEL=<level>
-# whre 1 < level < 16 (usually values up to 5 are enough)
+# where 1 < level < 16 (usually values up to 5 are enough)
 #LC_CFLAGS="$LC_FLAGS -DDEBUG"
 
 # Change workdir to simplify args
@@ -164,7 +164,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Fix stuff that configure failed to detect
-# TODO: Investigate for more ellegant patches
+# TODO: Investigate for more elegant patches
 if [ "$ARCH" == "arm64" ]; then
   sed -i -e 's/#define HAVE_DECL_PTRACE_POKEUSER 1/#define HAVE_DECL_PTRACE_POKEUSER 0/g' include/config.h
   echo "#define HAVE_DECL_PT_GETREGSET 1" >> include/config.h


### PR DESCRIPTION
libunwind cross-compile static lib imports have been re-ordered to resolve the "_Ux86_64_setcontext" compilation issue for Android x86_64 builds. Build has been tested against API-21, API-22 & AOSP master x86_64 emulator images and works like a charm. Android doc compatibility list has been updated to reflect that too.

Also fixed the PTRACE_GETREGS fail-over compatibility since Android aarch64 doesn't implement it.

Minor typos fixed too.