### PR TITLE
ptrace ARM fix, hardlinks copy failover, dynamic workspace & report file improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mach_excServer.h
 mach_excServer.c
 libs
 obj
+examples/targets/badcode1

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -18,6 +18,12 @@ LOCAL_PATH := $(abspath $(call my-dir)/..)
 # Enable Linux ptrace() instead of POSIX signal interface by default 
 ANDROID_WITH_PTRACE ?= true
 
+# Make sure compiler toolchain is compatible / supported
+ifneq (,$(findstring clang,$(NDK_TOOLCHAIN)))
+  $(error Clang toolchains are not supported yet. Clang uses __aeabi_read_tp to \
+  implement thread_local, which isn't supported by bionic [$(NDK_TOOLCHAIN)])
+endif
+
 ifeq ($(ANDROID_WITH_PTRACE),true)
   ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi armeabi-v7a))
     ARCH_ABI := arm

--- a/common.h
+++ b/common.h
@@ -101,6 +101,8 @@ typedef struct {
     int dynamicRegressionCnt;
     uint64_t dynamicCutOffAddr;
     pthread_mutex_t dynamicFile_mutex;
+    bool disableRandomization;
+    bool msanReportUMRS;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {

--- a/common.h
+++ b/common.h
@@ -101,8 +101,6 @@ typedef struct {
     int dynamicRegressionCnt;
     uint64_t dynamicCutOffAddr;
     pthread_mutex_t dynamicFile_mutex;
-    bool disableRandomization;
-    bool msanReportUMRS;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {

--- a/common.h
+++ b/common.h
@@ -68,6 +68,7 @@ typedef struct {
     bool saveUnique;
     bool useScreen;
     char *fileExtn;
+    char *workDir;
     double flipRate;
     char *externalCommand;
     const char *dictionaryFile;

--- a/files.c
+++ b/files.c
@@ -325,13 +325,15 @@ bool files_parseDictionary(honggfuzz_t * hfuzz)
  */
 bool files_copyFile(const char *source, const char *destination, bool * dstExists)
 {
-    if (dstExists) *dstExists = false;
+    if (dstExists)
+        *dstExists = false;
     if (link(source, destination) == 0) {
         return true;
     } else {
         if (errno == EEXIST) {
             // Should kick-in before MAC, so avoid the hassle
-            if (dstExists) *dstExists = true;
+            if (dstExists)
+                *dstExists = true;
             return false;
         } else {
             LOGMSG_P(l_DEBUG, "Couldn't link '%s' as '%s'", source, destination);
@@ -366,7 +368,8 @@ bool files_copyFile(const char *source, const char *destination, bool * dstExist
     outFD = open(destination, dstOpenFlags, dstFilePerms);
     if (outFD == -1) {
         if (errno == EEXIST) {
-            if (dstExists) *dstExists = true;
+            if (dstExists)
+                *dstExists = true;
         }
         LOGMSG_P(l_DEBUG, "Couldn't open '%s' destination", destination);
         close(inFD);

--- a/files.c
+++ b/files.c
@@ -325,13 +325,13 @@ bool files_parseDictionary(honggfuzz_t * hfuzz)
  */
 bool files_copyFile(const char *source, const char *destination, bool * dstExists)
 {
-    *dstExists = false;
+    if (*dstExists) *dstExists = false;
     if (link(source, destination) == 0) {
         return true;
     } else {
         if (errno == EEXIST) {
             // Should kick-in before MAC, so avoid the hassle
-            *dstExists = true;
+            if (*dstExists) *dstExists = true;
             return false;
         } else {
             LOGMSG_P(l_DEBUG, "Couldn't link '%s' as '%s'", source, destination);
@@ -366,7 +366,7 @@ bool files_copyFile(const char *source, const char *destination, bool * dstExist
     outFD = open(destination, dstOpenFlags, dstFilePerms);
     if (outFD == -1) {
         if (errno == EEXIST) {
-            *dstExists = true;
+            if (*dstExists) *dstExists = true;
         }
         LOGMSG_P(l_DEBUG, "Couldn't open '%s' destination", destination);
         close(inFD);

--- a/files.c
+++ b/files.c
@@ -325,13 +325,13 @@ bool files_parseDictionary(honggfuzz_t * hfuzz)
  */
 bool files_copyFile(const char *source, const char *destination, bool * dstExists)
 {
-    if (*dstExists) *dstExists = false;
+    if (dstExists) *dstExists = false;
     if (link(source, destination) == 0) {
         return true;
     } else {
         if (errno == EEXIST) {
             // Should kick-in before MAC, so avoid the hassle
-            if (*dstExists) *dstExists = true;
+            if (dstExists) *dstExists = true;
             return false;
         } else {
             LOGMSG_P(l_DEBUG, "Couldn't link '%s' as '%s'", source, destination);
@@ -366,7 +366,7 @@ bool files_copyFile(const char *source, const char *destination, bool * dstExist
     outFD = open(destination, dstOpenFlags, dstFilePerms);
     if (outFD == -1) {
         if (errno == EEXIST) {
-            if (*dstExists) *dstExists = true;
+            if (dstExists) *dstExists = true;
         }
         LOGMSG_P(l_DEBUG, "Couldn't open '%s' destination", destination);
         close(inFD);

--- a/files.h
+++ b/files.h
@@ -47,6 +47,6 @@ extern char *files_basename(char *fileName);
 
 extern bool files_parseDictionary(honggfuzz_t * hfuzz);
 
-extern int files_copyFile(const char *source, const char *destination);
+extern bool files_copyFile(const char *source, const char *destination, bool * dstExists);
 
 #endif

--- a/files.h
+++ b/files.h
@@ -47,4 +47,6 @@ extern char *files_basename(char *fileName);
 
 extern bool files_parseDictionary(honggfuzz_t * hfuzz);
 
+extern int files_copyFile(const char *source, const char *destination);
+
 #endif

--- a/fuzz.c
+++ b/fuzz.c
@@ -83,7 +83,7 @@ static void fuzz_getFileName(honggfuzz_t * hfuzz, char *fileName)
     struct timeval tv;
     gettimeofday(&tv, NULL);
 
-    snprintf(fileName, PATH_MAX, ".honggfuzz.%d.%lu.%llx.%s", (int)getpid(),
+    snprintf(fileName, PATH_MAX, "%s/.honggfuzz.%d.%lu.%llx.%s", hfuzz->workDir, (int)getpid(),
              (unsigned long int)tv.tv_sec, (unsigned long long int)util_rndGet(0, 1ULL << 62),
              hfuzz->fileExtn);
 
@@ -158,8 +158,7 @@ static bool fuzz_prepareFileExternally(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, i
 {
     int dstfd = open(fuzzer->fileName, O_CREAT | O_EXCL | O_RDWR, 0644);
     if (dstfd == -1) {
-        LOGMSG_P(l_ERROR, "Couldn't create a temporary file '%s' in the current directory",
-                 fuzzer->fileName);
+        LOGMSG_P(l_ERROR, "Couldn't create a temporary file '%s'", fuzzer->fileName);
         return false;
     }
 
@@ -335,12 +334,14 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz)
                 fuzzer.branchCnt[3] >
                 hfuzz->branchBestCnt[3] ? fuzzer.branchCnt[3] : hfuzz->branchBestCnt[3];
 
-#define _HF_CURRENT_BEST "CURRENT_BEST"
-#define _HF_CURRENT_BEST_TMP ".tmp.CURRENT_BEST"
+            char currentBest[PATH_MAX], currentBestTmp[PATH_MAX];
+            snprintf(currentBest, PATH_MAX, "%s/CURRENT_BEST", hfuzz->workDir);
+            snprintf(currentBestTmp, PATH_MAX, "%s/.tmp.CURRENT_BEST", hfuzz->workDir);
+
             if (files_writeBufToFile
-                (_HF_CURRENT_BEST_TMP, fuzzer.dynamicFile, fuzzer.dynamicFileSz,
+                (currentBestTmp, fuzzer.dynamicFile, fuzzer.dynamicFileSz,
                  O_WRONLY | O_CREAT | O_TRUNC)) {
-                rename(_HF_CURRENT_BEST_TMP, _HF_CURRENT_BEST);
+                rename(currentBestTmp, currentBest);
             }
         }
         MX_UNLOCK(&hfuzz->dynamicFile_mutex);

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -88,6 +88,8 @@ static void usage(bool exit_success)
 #if defined(_HF_ARCH_LINUX)
            " [" AB "-p val" AC "] : [Linux] attach to a pid (and its thread group), instead of \n"
            "            monitoring a previously created process, (default: '" AB "0" AC "' [none])\n"
+           " [" AB "-LR" AC "]    : [Linux] Don't disable ASLR randomization, might be useful with MSAN\n"
+           " [" AB "-LU" AC "]    : [Linux] Report MSAN's UMRS (uninitialized memory access)\n"
            " [" AB "-g val" AC "] : [Linux] allow that many regressions (perf events) wrt the best one\n"
            " [" AB "-o val" AC "] : [Linux] cut-off address, don't record branches above that address\n"
            " [" AB "-D val" AC "] : [Linux] create a file dynamically with Linux perf counters,\n"
@@ -171,6 +173,9 @@ int main(int argc, char **argv)
         .dynamicRegressionCnt = 0,
         .dynamicCutOffAddr = ~(0ULL),
         .dynamicFile_mutex = PTHREAD_MUTEX_INITIALIZER,
+
+        .disableRandomization = true,
+        .msanReportUMRS = false,
     };
 
     if (argc < 2) {
@@ -178,7 +183,7 @@ int main(int argc, char **argv)
     }
 
     for (;;) {
-        c = getopt(argc, argv, "-?hqvsuf:d:e:W:r:c:F:D:t:a:R:n:N:l:p:g:o:E:w:");
+        c = getopt(argc, argv, "-?hqvsuf:d:e:W:r:c:F:D:t:a:R:n:N:l:p:g:o:E:w:L:");
         if (c < 0)
             break;
 
@@ -281,11 +286,25 @@ int main(int argc, char **argv)
         case 'w':
             hfuzz.dictionaryFile = optarg;
             break;
+        case 'L':
+            switch (optarg[0]) {
+            case 'R':
+                hfuzz.disableRandomization = false;
+                break;
+            case 'U':
+                hfuzz.msanReportUMRS = true;
+                break;
+            default:
+                LOGMSG(l_ERROR, "Unknown -L switch");
+                usage(EXIT_FAILURE);
+            }
         default:
             break;
         }
     }
     hfuzz.cmdline = &argv[optind];
+
+    log_setMinLevel(ll);
 
     if (hfuzz.dynamicFileBestSz > hfuzz.maxFileSz) {
         LOGMSG(l_FATAL,

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -69,6 +69,8 @@ static void usage(bool exit_success)
            " [" AB "-d val" AC "] : debug level (0 - FATAL ... 4 - DEBUG), (default: '" AB "3" AC
            "' [INFO])\n"
            " [" AB "-e val" AC "] : file extension (e.g. 'swf'), (default: '" AB "fuzz" AC "')\n"
+           " [" AB "-W val" AC "] : Workspace directory to save crashes & runtime files\n"
+           "            (default: current '.')\n"
            " [" AB "-r val" AC "] : flip rate, (default: '" AB "0.001" AC "')\n"
            " [" AB "-w val" AC "] : wordlist, (default: empty) [tokens delimited by NUL-bytes]\n"
            " [" AB "-c val" AC "] : external command modifying the input corpus of files,\n"
@@ -138,6 +140,7 @@ int main(int argc, char **argv)
         .fuzzStdin = false,
         .saveUnique = false,
         .fileExtn = "fuzz",
+        .workDir = ".",
         .flipRate = 0.001f,
         .externalCommand = NULL,
         .dictionaryFile = NULL,
@@ -176,7 +179,7 @@ int main(int argc, char **argv)
     }
 
     for (;;) {
-        c = getopt(argc, argv, "-?hqvsuf:d:e:r:c:F:D:t:a:R:n:N:l:p:g:o:E:w:");
+        c = getopt(argc, argv, "-?hqvsuf:d:e:W:r:c:F:D:t:a:R:n:N:l:p:g:o:E:w:");
         if (c < 0)
             break;
 
@@ -205,6 +208,9 @@ int main(int argc, char **argv)
             break;
         case 'e':
             hfuzz.fileExtn = optarg;
+            break;
+        case 'W':
+            hfuzz.workDir = optarg;
             break;
         case 'r':
             hfuzz.flipRate = strtod(optarg, NULL);

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -261,8 +261,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
     for (;;) {
         int status;
-        pid_t pid =
-            TEMP_FAILURE_RETRY(wait4(childPid, &status, __WNOTHREAD | __WALL | WUNTRACED, NULL));
+        pid_t pid = wait4(childPid, &status, __WNOTHREAD | __WALL | WUNTRACED, NULL);
         if (pid == -1 && errno == EINTR) {
             continue;
         }
@@ -286,11 +285,10 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         int status;
 
         // wait3 syscall is no longer present in Android
-        // wrap syscalls under TEMP_FAILURE_RETRY macro to avoid "Interrupted system call"
 #if !defined(__ANDROID__)
-        pid_t pid = TEMP_FAILURE_RETRY(wait3(&status, __WNOTHREAD | __WALL, NULL));
+        pid_t pid = wait3(&status, __WNOTHREAD | __WALL, NULL);
 #else
-        pid_t pid = TEMP_FAILURE_RETRY(wait4(-1, &status, __WNOTHREAD | __WALL, NULL));
+        pid_t pid = wait4(fuzzer->pid, &status, __WNOTHREAD | __WALL, NULL);
 #endif
 
         LOGMSG(l_DEBUG, "PID '%d' returned with status '%d'", pid, status);

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -71,17 +71,6 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
         return false;
     }
 
-    const char *msan_options =
-        "exit_code=" HF_MSAN_EXIT_CODE_STR ":report_umrs=0:wrap_signals=0:print_stats=1";
-    if (hfuzz->msanReportUMRS == true) {
-        msan_options =
-            "exit_code=" HF_MSAN_EXIT_CODE_STR ":report_umrs=1:wrap_signals=0:print_stats=1";
-    }
-    if (setenv("MSAN_OPTIONS", msan_options, 1) == -1) {
-        LOGMSG_P(l_ERROR, "setenv(MSAN_OPTIONS) failed");
-        return false;
-    }
-
     /*
      * Kill the children when fuzzer dies (e.g. due to Ctrl+C)
      */
@@ -89,10 +78,11 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
         LOGMSG_P(l_ERROR, "prctl(PR_SET_PDEATHSIG, SIGKILL) failed");
         return false;
     }
+
     /*
      * Disable ASLR
      */
-    if (hfuzz->disableRandomization && personality(ADDR_NO_RANDOMIZE) == -1) {
+    if (personality(ADDR_NO_RANDOMIZE) == -1) {
         LOGMSG_P(l_ERROR, "personality(ADDR_NO_RANDOMIZE) failed");
         return false;
     }
@@ -293,7 +283,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         pid_t pid = TEMP_FAILURE_RETRY(wait4(-1, &status, __WNOTHREAD | __WALL, NULL));
 #endif
 
-        LOGMSG(l_DEBUG, "PID '%d' returned with status '%d'", pid, status);
+        LOGMSG_P(l_DEBUG, "PID '%d' returned with status '%d'", pid, status);
 
         if (pid == -1 && errno == EINTR) {
             arch_checkTimeLimit(hfuzz, fuzzer);

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -705,15 +705,16 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
                  instr, localtmstr, pid, fuzzer->origFileName, hfuzz->fileExtn);
     }
 
-    if (files_copyFile(fuzzer->fileName, newname) == 0) {
+    bool dstFileExists = false;
+    if (files_copyFile(fuzzer->fileName, newname, &dstFileExists)) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
     } else {
-        if (errno == EEXIST) {
+        if (dstFileExists) {
             LOGMSG(l_INFO, "It seems that '%s' already exists, skipping", newname);
             // Don't bother unwinding & generating reports for duplicate crashes
             return;
         } else {
-            LOGMSG_P(l_ERROR, "Couldn't link '%s' to '%s'", fuzzer->fileName, newname);
+            LOGMSG(l_ERROR, "Couldn't copy '%s' to '%s'", fuzzer->fileName, newname);
         }
     }
 

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -693,15 +693,15 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     char newname[PATH_MAX];
     if (hfuzz->saveUnique) {
         snprintf(newname, sizeof(newname),
-                 "%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%s",
-                 arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
+                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%s",
+                 hfuzz->workDir, arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
                  instr, fuzzer->origFileName, hfuzz->fileExtn);
     } else {
         char localtmstr[PATH_MAX];
         util_getLocalTime("%F.%H:%M:%S", localtmstr, sizeof(localtmstr));
         snprintf(newname, sizeof(newname),
-                 "%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%d.%s.%s",
-                 arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
+                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%d.%s.%s",
+                 hfuzz->workDir, arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
                  instr, localtmstr, pid, fuzzer->origFileName, hfuzz->fileExtn);
     }
 

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -439,7 +439,18 @@ uint64_t arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid)
 
 static size_t arch_getPC(pid_t pid, REG_TYPE * pc, REG_TYPE * status_reg)
 {
+    /* 
+     * Some old ARM android kernels are failing with PTRACE_GETREGS to extract
+     * the correct register values if struct size is bigger than expected. As such the
+     * 32/64-bit multiplexing trick is not working for them in case PTRACE_GETREGSET
+     * fails or is not implemented. To cover such cases we explicitly define
+     * the struct size to 32bit version for arm CPU.
+     */
+#if defined(__arm__)
+    struct user_regs_struct_32 regs;
+#else
     HEADERS_STRUCT regs;
+#endif
     struct iovec pt_iov = {
         .iov_base = &regs,
         .iov_len = sizeof(regs),

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -705,7 +705,7 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
                  instr, localtmstr, pid, fuzzer->origFileName, hfuzz->fileExtn);
     }
 
-    if (link(fuzzer->fileName, newname) == 0) {
+    if (files_copyFile(fuzzer->fileName, newname) == 0) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
     } else {
         if (errno == EEXIST) {

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -328,8 +328,6 @@ struct {
     [0 ... (NSIG - 1)].important = false,
     [0 ... (NSIG - 1)].descr = "UNKNOWN",
 
-    [SIGTRAP].important = false,
-    [SIGTRAP].descr = "SIGTRAP",
     [SIGILL].important = true,
     [SIGILL].descr = "SIGILL",
     [SIGFPE].important = true,
@@ -441,7 +439,18 @@ uint64_t arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid)
 
 static size_t arch_getPC(pid_t pid, REG_TYPE * pc, REG_TYPE * status_reg)
 {
+    /* 
+     * Some old ARM android kernels are failing with PTRACE_GETREGS to extract
+     * the correct register values if struct size is bigger than expected. As such the
+     * 32/64-bit multiplexing trick is not working for them in case PTRACE_GETREGSET
+     * fails or is not implemented. To cover such cases we explicitly define
+     * the struct size to 32bit version for arm CPU.
+     */
+#if defined(__arm__)
+    struct user_regs_struct_32 regs;
+#else
     HEADERS_STRUCT regs;
+#endif
     struct iovec pt_iov = {
         .iov_base = &regs,
         .iov_len = sizeof(regs),
@@ -616,13 +625,13 @@ static void arch_getInstrStr(pid_t pid, REG_TYPE * pc, char *instr)
 }
 
 static void
-arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs,
-                          size_t funcCnt, siginfo_t * si, const char *instr)
+arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs, size_t funcCnt,
+                          siginfo_t * si, const char *instr, const char *crashName)
 {
     fuzzer->report[0] = '\0';
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "ORIG_FNAME: %s\n",
                    fuzzer->origFileName);
-    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FUZZ_FNAME: %s\n", fuzzer->fileName);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FUZZ_FNAME: %s\n", crashName);
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "PID: %d\n", pid);
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "SIGNAL: %s (%d)\n",
                    arch_sigs[si->si_signo].descr, si->si_signo);
@@ -657,15 +666,14 @@ arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs,
 
 static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzzer)
 {
-    __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
     REG_TYPE pc = 0;
 
     char instr[_HF_INSTR_SZ] = "\x00";
     siginfo_t si;
-    bzero(&si, sizeof(si));
 
     if (ptrace(PT_GETSIGINFO, pid, 0, &si) == -1) {
         LOGMSG_P(l_WARN, "Couldn't get siginfo for pid %d", pid);
+        return;
     }
 
     arch_getInstrStr(pid, &pc, instr);
@@ -685,27 +693,28 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     char newname[PATH_MAX];
     if (hfuzz->saveUnique) {
         snprintf(newname, sizeof(newname),
-                 "%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s",
-                 arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
-                 instr, hfuzz->fileExtn);
+                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%s",
+                 hfuzz->workDir, arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
+                 instr, fuzzer->origFileName, hfuzz->fileExtn);
     } else {
         char localtmstr[PATH_MAX];
         util_getLocalTime("%F.%H:%M:%S", localtmstr, sizeof(localtmstr));
         snprintf(newname, sizeof(newname),
-                 "%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%d.%s",
-                 arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
-                 instr, localtmstr, pid, hfuzz->fileExtn);
+                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%d.%s.%s",
+                 hfuzz->workDir, arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
+                 instr, localtmstr, pid, fuzzer->origFileName, hfuzz->fileExtn);
     }
 
-    if (link(fuzzer->fileName, newname) == 0) {
+    bool dstFileExists = false;
+    if (files_copyFile(fuzzer->fileName, newname, &dstFileExists)) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
     } else {
-        if (errno == EEXIST) {
+        if (dstFileExists) {
             LOGMSG(l_INFO, "It seems that '%s' already exists, skipping", newname);
             // Don't bother unwinding & generating reports for duplicate crashes
             return;
         } else {
-            LOGMSG_P(l_ERROR, "Couldn't link '%s' to '%s'", fuzzer->fileName, newname);
+            LOGMSG(l_ERROR, "Couldn't copy '%s' to '%s'", fuzzer->fileName, newname);
         }
     }
 
@@ -723,36 +732,14 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     size_t funcCnt = arch_unwindStack(pid, funcs);
 #endif
 
-    arch_ptraceGenerateReport(pid, fuzzer, funcs, funcCnt, &si, instr);
+    arch_ptraceGenerateReport(pid, fuzzer, funcs, funcCnt, &si, instr, newname);
+    __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
 }
 
 #define __WEVENT(status) ((status & 0xFF0000) >> 16)
-static void arch_ptraceEvent(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, int status, pid_t pid)
+static void arch_ptraceEvent(int status, pid_t pid)
 {
-    unsigned long event_msg;
-    if (ptrace(PTRACE_GETEVENTMSG, pid, NULL, &event_msg) == -1) {
-        LOGMSG(l_ERROR, "ptrace(PTRACE_GETEVENTMSG,%d) failed", pid);
-        return;
-    }
-
-    LOGMSG(l_DEBUG, "PID: %d, Ptrace event: %d, event_msg: %ld", pid, __WEVENT(status), event_msg);
-    switch (__WEVENT(status)) {
-    case PTRACE_EVENT_EXIT:
-        if (WIFEXITED(event_msg)) {
-            LOGMSG(l_DEBUG, "PID: %d exited with exit_code: %d", pid, WEXITSTATUS(event_msg));
-            if (WEXITSTATUS(event_msg) == HF_MSAN_EXIT_CODE) {
-                arch_ptraceSaveData(hfuzz, pid, fuzzer);
-            }
-        } else if (WIFSIGNALED(event_msg)) {
-            LOGMSG(l_DEBUG, "PID: %d terminated with signal: %d", pid, WTERMSIG(event_msg));
-        } else {
-            LOGMSG(l_DEBUG, "PID: %d exited with unknown status: %ld", pid, event_msg);
-        }
-        break;
-    default:
-        break;
-    }
-
+    LOGMSG(l_DEBUG, "PID: %d, Ptrace event %d", pid, __WEVENT(status));
     ptrace(PT_CONTINUE, pid, 0, 0);
     return;
 }
@@ -763,7 +750,7 @@ void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * f
      * It's a ptrace event, deal with it elsewhere
      */
     if (WIFSTOPPED(status) && __WEVENT(status)) {
-        return arch_ptraceEvent(hfuzz, fuzzer, status, pid);
+        return arch_ptraceEvent(status, pid);
     }
 
     if (WIFSTOPPED(status)) {
@@ -799,11 +786,7 @@ void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * f
     /*
      * Process exited
      */
-    if (WIFEXITED(status)) {
-        return;
-    }
-
-    if (WIFSIGNALED(status)) {
+    if (WIFEXITED(status) || WIFSIGNALED(status)) {
         return;
     }
 

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -625,13 +625,13 @@ static void arch_getInstrStr(pid_t pid, REG_TYPE * pc, char *instr)
 }
 
 static void
-arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs,
-                          size_t funcCnt, siginfo_t * si, const char *instr)
+arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs, size_t funcCnt,
+                          siginfo_t * si, const char *instr, const char *crashName)
 {
     fuzzer->report[0] = '\0';
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "ORIG_FNAME: %s\n",
                    fuzzer->origFileName);
-    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FUZZ_FNAME: %s\n", fuzzer->fileName);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FUZZ_FNAME: %s\n", crashName);
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "PID: %d\n", pid);
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "SIGNAL: %s (%d)\n",
                    arch_sigs[si->si_signo].descr, si->si_signo);
@@ -731,7 +731,7 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     size_t funcCnt = arch_unwindStack(pid, funcs);
 #endif
 
-    arch_ptraceGenerateReport(pid, fuzzer, funcs, funcCnt, &si, instr);
+    arch_ptraceGenerateReport(pid, fuzzer, funcs, funcCnt, &si, instr, newname);
     __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
 }
 

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -696,16 +696,16 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     char newname[PATH_MAX];
     if (hfuzz->saveUnique) {
         snprintf(newname, sizeof(newname),
-                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%s",
+                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s",
                  hfuzz->workDir, arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
-                 instr, fuzzer->origFileName, hfuzz->fileExtn);
+                 instr, hfuzz->fileExtn);
     } else {
         char localtmstr[PATH_MAX];
         util_getLocalTime("%F.%H:%M:%S", localtmstr, sizeof(localtmstr));
         snprintf(newname, sizeof(newname),
-                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%d.%s.%s",
+                 "%s/%s.PC.%" REG_PM ".CODE.%d.ADDR.%p.INSTR.%s.%s.%d.%s",
                  hfuzz->workDir, arch_sigs[si.si_signo].descr, pc, si.si_code, si.si_addr,
-                 instr, localtmstr, pid, fuzzer->origFileName, hfuzz->fileExtn);
+                 instr, localtmstr, pid, hfuzz->fileExtn);
     }
 
     bool dstFileExists = false;

--- a/linux/ptrace_utils.h
+++ b/linux/ptrace_utils.h
@@ -24,6 +24,9 @@
 #ifndef _LINUX_PTRACE_UTILS_H_
 #define _LINUX_PTRACE_UTILS_H_
 
+#define HF_MSAN_EXIT_CODE 103
+#define HF_MSAN_EXIT_CODE_STR "103"
+
 extern bool arch_ptraceEnable(honggfuzz_t * fuzz);
 extern void arch_ptraceAnalyze(honggfuzz_t * fuzz, int status, pid_t pid, fuzzer_t * fuzzer);
 extern bool arch_ptraceAttach(pid_t pid);

--- a/linux/ptrace_utils.h
+++ b/linux/ptrace_utils.h
@@ -24,9 +24,6 @@
 #ifndef _LINUX_PTRACE_UTILS_H_
 #define _LINUX_PTRACE_UTILS_H_
 
-#define HF_MSAN_EXIT_CODE 103
-#define HF_MSAN_EXIT_CODE_STR "103"
-
 extern bool arch_ptraceEnable(honggfuzz_t * fuzz);
 extern void arch_ptraceAnalyze(honggfuzz_t * fuzz, int status, pid_t pid, fuzzer_t * fuzzer);
 extern bool arch_ptraceAttach(pid_t pid);

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -216,13 +216,14 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
                  hfuzz->fileExtn);
     }
 
-    if (files_copyFile(fuzzer->fileName, newname) == 0) {
+    bool dstFileExists = false;
+    if (files_copyFile(fuzzer->fileName, newname, &dstFileExists)) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
     } else {
-        if (errno == EEXIST) {
+        if (dstFileExists) {
             LOGMSG(l_INFO, "It seems that '%s' already exists, skipping", newname);
         } else {
-            LOGMSG_P(l_ERROR, "Couldn't link '%s' to '%s'", fuzzer->fileName, newname);
+            LOGMSG(l_ERROR, "Couldn't copy '%s' to '%s'", fuzzer->fileName, newname);
         }
     }
 

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -199,8 +199,8 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
 
     if (hfuzz->saveUnique) {
         snprintf(newname, sizeof(newname),
-                 "%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s.%s",
-                 arch_sigs[termsig].descr,
+                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s.%s",
+                 hfuzz->workDir, arch_sigs[termsig].descr,
                  exception_to_string(fuzzer->exception), fuzzer->pc,
                  fuzzer->backtrace, fuzzer->access, fuzzer->origFileName, hfuzz->fileExtn);
     } else {
@@ -209,8 +209,8 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
         util_getLocalTime("%F.%H.%M.%S", localtmstr, sizeof(localtmstr));
 
         snprintf(newname, sizeof(newname),
-                 "%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.TIME.%s.PID.%.5d.%s.%s",
-                 arch_sigs[termsig].descr,
+                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.TIME.%s.PID.%.5d.%s.%s",
+                 hfuzz->workDir, arch_sigs[termsig].descr,
                  exception_to_string(fuzzer->exception), fuzzer->pc,
                  fuzzer->backtrace, fuzzer->access, localtmstr, fuzzer->pid, fuzzer->origFileName,
                  hfuzz->fileExtn);

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -216,7 +216,7 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
                  hfuzz->fileExtn);
     }
 
-    if (link(fuzzer->fileName, newname) == 0) {
+    if (files_copyFile(fuzzer->fileName, newname) == 0) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
     } else {
         if (errno == EEXIST) {

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -118,8 +118,8 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
 
     LOGMSG(l_INFO, "Ok, that's interesting, saving the '%s' as '%s'", fuzzer->fileName, newname);
 
-    if (files_copyFile(fuzzer->fileName, newname) != 0) {
-        LOGMSG_P(l_ERROR, "Couldn't save '%s' as '%s'", fuzzer->fileName, newname);
+    if (files_copyFile(fuzzer->fileName, newname) == false) {
+        LOGMSG(l_ERROR, "Couldn't save '%s' as '%s'", fuzzer->fileName, newname);
     }
     return true;
 }

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -112,9 +112,9 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
     util_getLocalTime("%F.%H:%M:%S", localtmstr, sizeof(localtmstr));
 
     char newname[PATH_MAX];
-    snprintf(newname, sizeof(newname), "%s.%d.%s.%s.%s",
-             arch_sigs[termsig].descr, fuzzer->pid, localtmstr, fuzzer->origFileName,
-             hfuzz->fileExtn);
+    snprintf(newname, sizeof(newname), "%s/%s.%d.%s.%s.%s",
+             hfuzz->workDir, arch_sigs[termsig].descr, fuzzer->pid, localtmstr,
+             fuzzer->origFileName, hfuzz->fileExtn);
 
     LOGMSG(l_INFO, "Ok, that's interesting, saving the '%s' as '%s'", fuzzer->fileName, newname);
 

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -118,7 +118,7 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
 
     LOGMSG(l_INFO, "Ok, that's interesting, saving the '%s' as '%s'", fuzzer->fileName, newname);
 
-    if (link(fuzzer->fileName, newname) == -1) {
+    if (files_copyFile(fuzzer->fileName, newname) != 0) {
         LOGMSG_P(l_ERROR, "Couldn't save '%s' as '%s'", fuzzer->fileName, newname);
     }
     return true;

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -40,6 +40,7 @@
 
 #include "log.h"
 #include "util.h"
+#include "files.h"
 
 #ifdef __ANDROID__
 #ifndef WIFCONTINUED
@@ -118,7 +119,7 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
 
     LOGMSG(l_INFO, "Ok, that's interesting, saving the '%s' as '%s'", fuzzer->fileName, newname);
 
-    if (files_copyFile(fuzzer->fileName, newname) == false) {
+    if (files_copyFile(fuzzer->fileName, newname, NULL) == false) {
         LOGMSG(l_ERROR, "Couldn't save '%s' as '%s'", fuzzer->fileName, newname);
     }
     return true;


### PR DESCRIPTION
* GETREGS fix for old ARM kernels
    - PTRACE_GETREGS for some old ARM kernels is failing to extract register values if provided struct size is bigger than expected pt_regs. Bug is fixed by avoiding 32/64-bit structs multiplexing for ARM kernels. arch_getPC() will always execute the 32bit branch so no further pre-processor pollution is required.
    - Bug has been spotted when fuzzing with Nexus4 5.1.1 running 3.4 kernel

* Bypass hardlink restrictions
    - Running environment might prevent hardlinks (e.g. SELinux restrictions in Android). As such fuzzer is failing to write identified crashes. A new copyFile helper function has been introduced to bypass such hardlink restrictions by failing over to a manual POSIX implementation.
    - Destination file O_EXCL attr. is ensuring that unique crashes feature will be functionally identical since existing files are successfully detected.

*  .gitignore update to exclude example binary