### PR TITLE
Small bug fixes in refactored code

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -82,7 +82,7 @@ endif
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := honggfuzz
-LOCAL_SRC_FILES := honggfuzz.c log.c files.c fuzz.c report.c mangle.c util.c
+LOCAL_SRC_FILES := honggfuzz.c display.c log.c files.c fuzz.c report.c mangle.c util.c
 LOCAL_CFLAGS := -std=c11 -I. \
     -D_GNU_SOURCE \
     -Wall -Wextra -Wno-initializer-overrides -Wno-override-init \

--- a/log.c
+++ b/log.c
@@ -74,7 +74,7 @@ void log_mutexLock(void)
 void log_mutexUnLock(void)
 {
     while (pthread_mutex_unlock(&log_mutex)) ;
-};
+}
 
 void log_msg(log_level_t dl, bool perr, const char *file, const char *func, int line,
              const char *fmt, ...)

--- a/report.c
+++ b/report.c
@@ -92,7 +92,7 @@ void report_Report(honggfuzz_t * hfuzz, char *s)
             " fuzzStdin    : %s\n"
             " timeout      : %ld (sec)\n"
             " ignoreAddr   : %p\n"
-            " memoryLimit  : %lu (MiB)\n"
+            " memoryLimit  : %llu (MiB)\n"
             " targetPid    : %d\n"
             " wordlistFile : %s\n",
             localtmstr,


### PR DESCRIPTION
* Missing display.c from Android makefile (TODO: Export some
   variables from main makefile to auto-inherit without need to manually update both)
* Extra semicolon (apart GCC doesn't give a damn about it)
* Integer format fix

Signed-off-by: Anestis Bechtsoudis <anestis@census-labs.com>