### PR TITLE
linux: Fix timeout

### DIFF
--- a/linux/arch.c
+++ b/linux/arch.c
@@ -293,8 +293,10 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
         LOGMSG(l_DEBUG, "PID '%d' returned with status '%d'", pid, status);
 
-        if (pid == -1 && errno == EINTR && hfuzz->tmOut) {
-            arch_checkTimeLimit(hfuzz, fuzzer);
+        if (pid == -1 && errno == EINTR) {
+            if (hfuzz->tmOut) {
+                arch_checkTimeLimit(hfuzz, fuzzer);
+            }
             continue;
         }
         if (pid == -1 && errno == ECHILD) {

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -293,7 +293,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
         LOGMSG(l_DEBUG, "PID '%d' returned with status '%d'", pid, status);
 
-        if (pid == -1 && errno == EINTR) {
+        if (pid == -1 && errno == EINTR && hfuzz->tmOut) {
             arch_checkTimeLimit(hfuzz, fuzzer);
             continue;
         }


### PR DESCRIPTION
anestisb@lpsma:~/dev/honggfuzz$ ./honggfuzz -f honggfuzz -n1 -N1 -q -u -v -t 0 -- ./long_exec.sh ___FILE___
...
[WARNING] PID 26499 took too much time (limit 0 s). Sending SIGKILL
[WARNING] PID 26499 took too much time (limit 0 s). Sending SIGKILL
[WARNING] PID 26499 took too much time (limit 0 s). Sending SIGKILL

Signed-off-by: Anestis Bechtsoudis <anestis@census-labs.com>