### PR TITLE
Display crash counters improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ else
 endif
 	CC = $(shell xcrun --sdk $(SDK_NAME) --find cc)
 	SDK = $(shell xcrun --sdk $(SDK_NAME) --show-sdk-path)
-	CFLAGS = -arch x86_64 -O3 -g -ggdb -std=c99 -isysroot $(SDK) -I. \
+	CFLAGS = -arch x86_64 -O3 -std=c99 -isysroot $(SDK) -I. \
 	    -x objective-c \
 		-D_GNU_SOURCE \
 		-pedantic \
@@ -102,6 +102,10 @@ SRCS += $(ARCH_SRCS)
 CFLAGS += -D_HF_ARCH_${ARCH}
 INTERCEPTOR_SRCS = $(wildcard interceptor/*.c)
 INTERCEPTOR_LIBS = $(INTERCEPTOR_SRCS:.c=.so)
+
+ifeq ($(DEBUG),true)
+	CFLAGS += -g -ggdb
+endif
 
 # Control Android builds
 ANDROID_DEBUG_ENABLED ?= false

--- a/common.h
+++ b/common.h
@@ -97,6 +97,7 @@ typedef struct {
     time_t timeStart;
     size_t mutationsCnt;
     size_t crashesCnt;
+    size_t uniqueCrashesCnt;
     size_t timeoutedCnt;
 
     /* For the linux/ code */

--- a/display.c
+++ b/display.c
@@ -95,8 +95,9 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
     display_put("Execs per second: " ESC_BOLD "%zu" ESC_RESET " (avg: " ESC_BOLD "%zu" ESC_RESET
                 ")\n", exec_per_sec, elapsed ? (curr_exec_cnt / elapsed) : 0);
 
-    display_put("Crashes: " ESC_BOLD "%zu" ESC_RESET "\n",
-                __sync_fetch_and_add(&hfuzz->crashesCnt, 0UL));
+    display_put("Crashes: " ESC_BOLD "%zu" ESC_RESET " (unique: " ESC_BOLD "%zu" ESC_RESET ") \n",
+                __sync_fetch_and_add(&hfuzz->crashesCnt, 0UL),
+                __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 0UL));
     display_put("Timeouts: " ESC_BOLD "%zu" ESC_RESET "\n",
                 __sync_fetch_and_add(&hfuzz->timeoutedCnt, 0UL));
 

--- a/fuzz.c
+++ b/fuzz.c
@@ -441,5 +441,8 @@ void fuzz_main(honggfuzz_t * hfuzz)
         LOGMSG(l_INFO, "Signal %d received, terminating", fuzz_sigReceived);
     }
 
+    free(hfuzz->files);
+    free(hfuzz->dynamicFileBest);
+
     _exit(EXIT_SUCCESS);
 }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -365,8 +365,6 @@ int main(int argc, char **argv)
      */
     fuzz_main(&hfuzz);
 
-    free(hfuzz.dynamicFileBest);
-
     abort();                    /* NOTREACHED */
     return EXIT_SUCCESS;
 }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -163,6 +163,7 @@ int main(int argc, char **argv)
         .timeStart = time(NULL),
         .mutationsCnt = 0,
         .crashesCnt = 0,
+        .uniqueCrashesCnt = 0,
         .timeoutedCnt = 0,
 
         .dynFileMethod = _HF_DYNFILE_NONE,

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -872,8 +872,7 @@ static bool arch_listThreads(int tasks[], size_t thrSz, int pid)
 bool arch_ptraceAttach(pid_t pid)
 {
 #define MAX_THREAD_IN_TASK 4096
-    int tasks[MAX_THREAD_IN_TASK + 1];
-    tasks[MAX_THREAD_IN_TASK] = 0;
+    int tasks[MAX_THREAD_IN_TASK + 1] = { 0 };
     if (!arch_listThreads(tasks, MAX_THREAD_IN_TASK, pid)) {
         LOGMSG(l_ERROR, "Couldn't read thread list for pid '%d'", pid);
         return false;

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -711,6 +711,7 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     bool dstFileExists = false;
     if (files_copyFile(fuzzer->fileName, newname, &dstFileExists)) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
+        __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 1UL);
     } else {
         if (dstFileExists) {
             LOGMSG(l_INFO, "It seems that '%s' already exists, skipping", newname);

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -216,9 +216,16 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
                  hfuzz->fileExtn);
     }
 
+    /*
+     * Increase crashes counter presented by ASCII display
+     */
+    __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
+
     bool dstFileExists = false;
     if (files_copyFile(fuzzer->fileName, newname, &dstFileExists)) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);
+        // Unique crashes
+        __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 1UL);
     } else {
         if (dstFileExists) {
             LOGMSG(l_INFO, "It seems that '%s' already exists, skipping", newname);

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -119,6 +119,12 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
 
     LOGMSG(l_INFO, "Ok, that's interesting, saving the '%s' as '%s'", fuzzer->fileName, newname);
 
+    /*
+     * All crashes are marked as unique due to lack of information in POSIX arch
+     */
+    __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
+    __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 1UL);
+
     if (files_copyFile(fuzzer->fileName, newname, NULL) == false) {
         LOGMSG(l_ERROR, "Couldn't save '%s' as '%s'", fuzzer->fileName, newname);
     }

--- a/util.c
+++ b/util.c
@@ -38,6 +38,18 @@
 #include "files.h"
 #include "log.h"
 
+#if defined(__builtin_bswap16)
+#define SWAP16(x)   __builtin_bswap16(x)
+#else
+#define SWAP16(x)   ((x & 0xff) << 8) | ((x & 0xff00) >> 8)
+#endif
+
+#if defined(__builtin_bswap32)
+#define SWAP32(x)   __builtin_bswap32(x)
+#else
+#define SWAP32(x)   ((x & 0xff) << 24) | ((x & 0xff00) << 8) | ((x & 0xff0000) >> 8) | ((x & 0xff000000) >> 24)
+#endif
+
 static int util_urandomFd = -1;
 
 uint64_t util_rndGet(uint64_t min, uint64_t max)
@@ -202,7 +214,7 @@ extern uint16_t util_ToFromBE16(uint16_t val)
 #if __BYTE_ORDER == __BIG_ENDIAN
     return val;
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap16(val);
+    return SWAP16(val);
 #else
 #error "Unknown ENDIANESS"
 #endif
@@ -211,7 +223,7 @@ extern uint16_t util_ToFromBE16(uint16_t val)
 extern uint16_t util_ToFromLE16(uint16_t val)
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
-    return __builtin_bswap16(val);
+    return SWAP16(val);
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
     return val;
 #else
@@ -224,7 +236,7 @@ extern uint32_t util_ToFromBE32(uint32_t val)
 #if __BYTE_ORDER == __BIG_ENDIAN
     return val;
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap32(val);
+    return SWAP32(val);
 #else
 #error "Unknown ENDIANESS"
 #endif
@@ -233,7 +245,7 @@ extern uint32_t util_ToFromBE32(uint32_t val)
 extern uint32_t util_ToFromLE32(uint32_t val)
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
-    return __builtin_bswap32(val);
+    return SWAP32(val);
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
     return val;
 #else


### PR DESCRIPTION
* Display crash counters improvements
    * Update display crashes counters for MAC & POSIX arch too
    * Add a unique crashes counter. Maybe it's an unnecessary overhead to add another member, although usually the comparison is a useful indicator of how often identical bugs are hit.
* Add DEBUG target flags in Makefile (arch agnostic)
    * Android DEBUG builds are already controlled with different flag due to different requirements in toolchains
* Fix GCC < 4.8 support
* Some small initialization / leaks detected by valgrind