### PR TITLE
Perf display fixes + Android bug fixes

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -44,7 +44,7 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   # Additional libcrypto OpenSSL flags required to mitigate bug (ARM systems with API <= 21)
   ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi))
     OPENSSL_ARMCAP_ABI := "5"
-  else
+  else ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi-v7a))
     OPENSSL_ARMCAP_ABI := "7"
   endif
 
@@ -108,6 +108,9 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   LOCAL_CFLAGS += -D__HF_USE_CAPSTONE__
   ARCH_SRCS := linux/arch.c linux/ptrace_utils.c linux/perf.c linux/unwind.c
   ARCH := LINUX
+  ifeq ($(ARCH_ABI),arm)
+    LOCAL_CFLAGS += -DOPENSSL_ARMCAP_ABI='$(OPENSSL_ARMCAP_ABI)'
+  endif
   $(info $(shell (echo "********************************************************************")))
   $(info $(shell (echo "Android PTRACE build: Will prevent debuggerd from processing crashes")))
   $(info $(shell (echo "********************************************************************")))
@@ -120,6 +123,6 @@ else
 endif
 
 LOCAL_SRC_FILES += $(ARCH_SRCS)
-LOCAL_CFLAGS += -D_HF_ARCH_${ARCH} -DOPENSSL_ARMCAP_ABI='$(OPENSSL_ARMCAP_ABI)'
+LOCAL_CFLAGS += -D_HF_ARCH_${ARCH}
 
 include $(BUILD_EXECUTABLE)

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -44,7 +44,7 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   # Additional libcrypto OpenSSL flags required to mitigate bug (ARM systems with API <= 21)
   ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi))
     OPENSSL_ARMCAP_ABI := "5"
-   else
+  else
     OPENSSL_ARMCAP_ABI := "7"
   endif
 

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -41,6 +41,13 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
     $(error Unsuported / Unknown APP_API '$(APP_ABI)')
   endif
 
+  # Additional libcrypto OpenSSL flags required to mitigate bug (ARM systems with API <= 21)
+  ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi))
+    OPENSSL_ARMCAP_ABI := "5"
+   else
+    OPENSSL_ARMCAP_ABI := "7"
+  endif
+
   # Upstream libunwind compiled from sources with Android NDK toolchain
   LIBUNWIND_A := third_party/android/libunwind/$(ARCH_ABI)/libunwind-$(UNW_ARCH).a
   ifeq ("$(wildcard $(LIBUNWIND_A))","")
@@ -113,6 +120,6 @@ else
 endif
 
 LOCAL_SRC_FILES += $(ARCH_SRCS)
-LOCAL_CFLAGS += -D_HF_ARCH_${ARCH}
+LOCAL_CFLAGS += -D_HF_ARCH_${ARCH} -DOPENSSL_ARMCAP_ABI='$(OPENSSL_ARMCAP_ABI)'
 
 include $(BUILD_EXECUTABLE)

--- a/fuzz.c
+++ b/fuzz.c
@@ -295,15 +295,15 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz)
                "File size (New/Best): %zu/%zu, Perf feedback (instr/branch/block/block-edge/custom): Best: [%"
                PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "] / New: [%" PRIu64 ",%"
                PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "]", fuzzer.dynamicFileSz,
-               hfuzz->dynamicFileBestSz, hfuzz->hwCnts.cpuBranchCnt, hfuzz->hwCnts.cpuInstrCnt,
+               hfuzz->dynamicFileBestSz, hfuzz->hwCnts.cpuInstrCnt, hfuzz->hwCnts.cpuBranchCnt,
                hfuzz->hwCnts.pcCnt, hfuzz->hwCnts.pathCnt, hfuzz->hwCnts.customCnt,
-               fuzzer.hwCnts.cpuBranchCnt, fuzzer.hwCnts.cpuInstrCnt, fuzzer.hwCnts.pcCnt,
+               fuzzer.hwCnts.cpuInstrCnt, fuzzer.hwCnts.cpuBranchCnt, fuzzer.hwCnts.pcCnt,
                fuzzer.hwCnts.pathCnt, fuzzer.hwCnts.customCnt);
 
         MX_LOCK(&hfuzz->dynamicFile_mutex);
 
-        int64_t diff0 = hfuzz->hwCnts.cpuBranchCnt - fuzzer.hwCnts.cpuBranchCnt;
-        int64_t diff1 = hfuzz->hwCnts.cpuInstrCnt - fuzzer.hwCnts.cpuInstrCnt;
+        int64_t diff0 = hfuzz->hwCnts.cpuInstrCnt - fuzzer.hwCnts.cpuInstrCnt;
+        int64_t diff1 = hfuzz->hwCnts.cpuBranchCnt - fuzzer.hwCnts.cpuBranchCnt;
         int64_t diff2 = hfuzz->hwCnts.pcCnt - fuzzer.hwCnts.pcCnt;
         int64_t diff3 = hfuzz->hwCnts.pathCnt - fuzzer.hwCnts.pathCnt;
         int64_t diff4 = hfuzz->hwCnts.customCnt - fuzzer.hwCnts.customCnt;
@@ -315,16 +315,16 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz)
                    "New BEST feedback: File Size (New/Old): %zu/%zu', Perf feedback (Curr, High): %"
                    PRId64 "/%" PRId64 "/%" PRId64 "/%" PRId64 "/%" PRId64 ",%" PRId64 "/%" PRId64
                    "/%" PRId64 "/%" PRId64 "/%" PRId64, fuzzer.dynamicFileSz,
-                   hfuzz->dynamicFileBestSz, hfuzz->hwCnts.cpuBranchCnt, hfuzz->hwCnts.cpuInstrCnt,
+                   hfuzz->dynamicFileBestSz, hfuzz->hwCnts.cpuInstrCnt, hfuzz->hwCnts.cpuBranchCnt,
                    hfuzz->hwCnts.pcCnt, hfuzz->hwCnts.pathCnt, hfuzz->hwCnts.customCnt,
-                   fuzzer.hwCnts.cpuBranchCnt, fuzzer.hwCnts.cpuInstrCnt, fuzzer.hwCnts.pcCnt,
+                   fuzzer.hwCnts.cpuInstrCnt, fuzzer.hwCnts.cpuBranchCnt, fuzzer.hwCnts.pcCnt,
                    fuzzer.hwCnts.pathCnt, fuzzer.hwCnts.customCnt);
 
             memcpy(hfuzz->dynamicFileBest, fuzzer.dynamicFile, fuzzer.dynamicFileSz);
 
             hfuzz->dynamicFileBestSz = fuzzer.dynamicFileSz;
-            hfuzz->hwCnts.cpuBranchCnt = fuzzer.hwCnts.cpuBranchCnt;
             hfuzz->hwCnts.cpuInstrCnt = fuzzer.hwCnts.cpuInstrCnt;
+            hfuzz->hwCnts.cpuBranchCnt = fuzzer.hwCnts.cpuBranchCnt;
             hfuzz->hwCnts.pcCnt = fuzzer.hwCnts.pcCnt;
             hfuzz->hwCnts.pathCnt = fuzzer.hwCnts.pathCnt;
             hfuzz->hwCnts.customCnt = fuzzer.hwCnts.customCnt;

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -339,12 +339,17 @@ bool arch_archInit(honggfuzz_t * hfuzz)
 
     if (hfuzz->dynFileMethod != _HF_DYNFILE_NONE) {
         /*
-         * Check that linux kernel is compatible
+         * Check that Linux kernel is compatible
          *
          * Compatibility list:
          *  1) Perf exclude_callchain_kernel requires kernel >= 3.7
          *     TODO: Runtime logic to disable it for unsupported kernels
          *           if it doesn't affect perf counters processing
+         *  2) If 'PERF_TYPE_HARDWARE' is not supported by kernel, ENOENT
+         *     is returned from perf_event_open(). Unfortunately, no reliable
+         *     way to detect it here. libperf exports some list functions,
+         *     although small guarantees it's installed. Maybe a more targeted 
+         *     message at perf_event_open() error handling will help.
          */
         struct utsname uts;
         if (uname(&uts) == -1) {

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -289,7 +289,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 #if !defined(__ANDROID__)
         pid_t pid = wait3(&status, __WNOTHREAD | __WALL, NULL);
 #else
-        pid_t pid = wait4(fuzzer->pid, &status, __WNOTHREAD | __WALL, NULL);
+        pid_t pid = wait4(-1, &status, __WNOTHREAD | __WALL, NULL);
 #endif
 
         LOGMSG(l_DEBUG, "PID '%d' returned with status '%d'", pid, status);

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -44,6 +44,7 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/utsname.h>
 
 #include "linux/perf.h"
 #include "linux/ptrace_utils.h"
@@ -333,8 +334,49 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
 bool arch_archInit(honggfuzz_t * hfuzz)
 {
-    return true;
-    if (hfuzz) {
-        return true;
+    unsigned long major = 0, minor = 0;
+    char *p = NULL;
+
+    if (hfuzz->dynFileMethod != _HF_DYNFILE_NONE) {
+        /*
+         * Check that linux kernel is compatible
+         *
+         * Compatibility list:
+         *  1) Perf exclude_callchain_kernel requires kernel >= 3.7
+         *     TODO: Runtime logic to disable it for unsupported kernels
+         *           if it doesn't affect perf counters processing
+         */
+        struct utsname uts;
+        if (uname(&uts) == -1) {
+            LOGMSG_P(l_FATAL, "uname() failed");
+            return false;
+        }
+
+        p = uts.release;
+        major = strtoul(p, &p, 10);
+        if (*p++ != '.') {
+            LOGMSG(l_FATAL, "Unsupported kernel version (%s)", uts.release);
+            return false;
+        }
+
+        minor = strtoul(p, &p, 10);
+        if ((major < 3) || ((major == 3) && (minor < 7))) {
+            LOGMSG(l_ERROR, "Unsupported kernel version (%s)", uts.release);
+            return false;
+        }
     }
+#if defined(__ANDROID__) && defined(__arm__)
+    /* 
+     * For ARM kernels running Android API <= 21, if fuzzing target links to 
+     * libcrypto (OpenSSL), OPENSSL_cpuid_setup initialization is triggering a
+     * SIGILL/ILLOPC at armv7_tick() due to  "mrrc p15, #1, r0, r1, c14)" instruction.
+     * Setups using BoringSSL (API >= 22) are not affected.
+     */
+    if (setenv("OPENSSL_armcap", OPENSSL_ARMCAP_ABI, 1) == -1) {
+        LOGMSG_P(l_ERROR, "setenv(OPENSSL_armcap) failed");
+        return false;
+    }
+#endif
+
+    return true;
 }


### PR DESCRIPTION
* Global:
    * Re-order perf counters printouts in display to match printed strings and general order convention
    * Detect incompatible kernels ( < 3.7 where 'exclude_callchain_kernel' is not supported) during archInit()

* Android issues:
    * Fix a bug in wait4() pid accidentally committed while conducting targeted testing
    * Fix an ARM bug triggered when fuzzing target links with libcrypto OpenSSL (yup it's one of those WTF times). Issue is fixed by exporting 'OPENSSL_ARMCAP' env variable with matching ABI value, preventing the init ARMv7 code that triggers the bug to be executed from spawned workers.
    * Most Android ARM devices run under 3.4 kernel unfortunately. Thus the effort to do the runtime version check. The good news is that I need some extensive testing under 3.10 kernels (Nexus6) and perf counters are working like a charm (good stuff :))