### PR TITLE
linux: Smarter unique crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ mach_excServer.c
 libs
 obj
 examples/targets/badcode1
+examples/targets/badcode2

--- a/examples/targets/Makefile
+++ b/examples/targets/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
-CFLAGS ?= -fno-stack-protector
+CFLAGS ?= -fno-stack-protector -Wno-builtin-memcpy-chk-size
 
-BINS = badcode1
+BINS = badcode1 badcode2
 
 all: $(BINS)
 	@(echo CC $<; $(CC) $(CFLAGS) $<.c -o $<)

--- a/examples/targets/badcode1.c
+++ b/examples/targets/badcode1.c
@@ -33,3 +33,4 @@ int main(int argc, char ** argv)
   }
   return output(argv[1]);
 }
+

--- a/examples/targets/badcode2.c
+++ b/examples/targets/badcode2.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+#include <unistd.h>
+
+#define EXPORT   __attribute__((visibility("default")))
+#define NOINLINE __attribute__ ((noinline))
+
+EXPORT NOINLINE void crash()
+{
+  char src[128];
+  char dst[2];
+  memcpy(src, dst, 8192);
+}
+
+EXPORT NOINLINE void func1()
+{
+  printf("func1\n");
+  crash();
+}
+
+EXPORT NOINLINE void func2() 
+{
+  printf("func2\n");
+  crash();
+}
+
+EXPORT NOINLINE void driver()
+{
+  srand(time(0));
+  sleep(1);
+  if (rand() % 2 == 1) func1();
+  else func2();
+}
+
+int main(int argc, char ** argv)
+{
+  driver();
+  return 0;
+}
+

--- a/linux/unwind.c
+++ b/linux/unwind.c
@@ -124,21 +124,21 @@ size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
         unw_word_t pc = 0, offset = 0;
         char buf[_HF_FUNC_NAME_SZ] = { 0 };
 
-        unw_proc_info_t frameInfo;
-        ret = unw_get_proc_info(&cursor, &frameInfo);
-        if (ret < 0) {
-            LOGMSG(l_DEBUG, "[pid='%d'] [%d] unw_get_proc_info (%s)",
-                   pid, num_frames, UNW_ER[-ret]);
-            // Not safe to keep reading
-            goto out;
-        }
-
         ret = unw_get_reg(&cursor, UNW_REG_IP, &pc);
         if (ret < 0) {
             LOGMSG(l_ERROR, "[pid='%d'] [%d] failed to read IP (%s)",
                    pid, num_frames, UNW_ER[-ret]);
             // We don't want to try to extract info from an arbitrary IP
             // TODO: Maybe abort completely (goto out))
+            goto skip_frame_info;
+        }
+
+        unw_proc_info_t frameInfo;
+        ret = unw_get_proc_info(&cursor, &frameInfo);
+        if (ret < 0) {
+            LOGMSG(l_DEBUG, "[pid='%d'] [%d] unw_get_proc_info (%s)",
+                   pid, num_frames, UNW_ER[-ret]);
+            // Not safe to keep parsing frameInfo
             goto skip_frame_info;
         }
 


### PR DESCRIPTION
When fuzzing with unique crashes enabled in Linux arch, if the same bug (same PC value)
is triggered under different execution path, fuzzer will miss it since the constructed output
filename will be the same and thus skipped.

Following the same philosophy with MAC arch, a callstack signature hash is created from
the last 3 nibbles of each frame's PC. This will effectively cover both the ASLR disabled
targets and attached PID targets which have (probably) ASLR enabled. Callstack hash is
added as part of both the output filename and report file.

However, since most modern targets use a pool of worker processes (e.g. media parsers),
whitelisting the entire backtrace might result into significant noise for cases where the bug
is triggered from the main thread or a worker. Plus other cases (e.g. matroska) where same
bug can be triggered with different exec paths based on how some locks were acquired at
runtime.

For previous reasons only the 7 most significant frames are participating into the callstack
signature. This value is controlled with NMAJORFRAMES macro and can be easily altered.
Another idea would be to export as a calling argument, although since args are quite a few
already, I've left it hardcoded.

As a PoC to verify the signature behavior badcode2 target has been added at the examples.