### PR TITLE
MAC build issue

### DIFF
--- a/mangle.c
+++ b/mangle.c
@@ -105,7 +105,7 @@ static void mangle_Magic(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_
     static const struct {
         const uint8_t val[8];
         const size_t size;
-    } const mangleMagicVals[] = {
+    } mangleMagicVals[] = {
         /* 1B - No endianness */
         { "\x00\x00\x00\x00\x00\x00\x00\x00", 1},
         { "\x01\x00\x00\x00\x00\x00\x00\x00", 1},


### PR DESCRIPTION
Redundant "const" breaks build with clang in OS X

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -c -arch x86_64 -O3 -std=c99 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -I. -x objective-c -D_GNU_SOURCE -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wreturn-type -Wpointer-arith -Wno-gnu-case-range -Wno-gnu-designator -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-attributes -D_HF_ARCH_DARWIN -o mangle.o mangle.c
mangle.c:108:7: error: duplicate 'const' declaration specifier [-Werror,-Wduplicate-decl-specifier]
    } const mangleMagicVals[] = {
      ^
1 error generated.
make: *** [mangle.o] Error 1