### PR TITLE
Usage typo

### DIFF
--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -107,7 +107,7 @@ static void usage(bool exit_success)
            " Run the binary over a mutated file chosen from the directory:\n"
            AB "  " PROG_NAME " -f input_dir -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER AC "\n"
            " As above, provide input over STDIN:\n"
-           AB "  " PROG_NAME " -f input_dir -- /usr/bin/djpeg\n" AC
+           AB "  " PROG_NAME " -f input_dir -s -- /usr/bin/djpeg\n" AC
 #if defined(_HF_ARCH_LINUX)
            " Run the binary over a dynamic file, maximize total no. of instructions:\n"
            AB "  " PROG_NAME " -Di -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER AC "\n"
@@ -250,7 +250,7 @@ int main(int argc, char **argv)
                 break;
             default:
                 LOGMSG(l_ERROR, "Unknown -D mode");
-                usage(EXIT_FAILURE);
+                usage(false);
                 break;
             }
             break;
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
                 break;
             default:
                 LOGMSG(l_ERROR, "Unknown -L switch");
-                usage(EXIT_FAILURE);
+                usage(false);
             }
         default:
             break;


### PR DESCRIPTION
* Fuzz from stdin example was missing "-s" flag
* Also update the usage() calls with a bool flag
  to be aligned with module conventions.

Signed-off-by: Anestis Bechtsoudis <anestis@census-labs.com>