### PR TITLE
makefile: Clean & more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 *.o
 *.so
-honggfuzz
+*.dylib
 *.dSYM
-mach_exc.h
-mach_excUser.c
-mach_excServer.h
-mach_excServer.c
+honggfuzz
+mac/mach_exc.h
+mac/mach_excUser.c
+mac/mach_excServer.h
+mac/mach_excServer.c
 libs
 obj
 examples/targets/badcode1


### PR DESCRIPTION
General:
* Move common flags outside the arch if-statements
* Each arch is defining additional flags (ARCH_xxx),
  which are then appended before rules take place.
* For dynamic libs set the suffix type based on the arch.
  MAC was having a .so for interceptor lib, instead of dylib.
  Small tricks to avoid libtool et. al.
* Fixed tabs/spaces that where mixed across the file
* Improve clean rule by defining all target subdirs. This will
  allow cross-platform cleans to be completed without
  leftovers.

Linux:
* Missing library warnings have been moved in matching
  arch statement.

MAC:
* Do some more error checking with xCode SDKs.
  For example xCode 7 is shipped in 10.10 (Yosemite)
  systems, but with 10.11 (El Capitan) SDK only.
* mig RPC generation has been moved before rules
  to ensure that always a latest copy of system is used
  even for non clean builds.
* Verify that mig RPC code generations has been
  completed successfully before rules.
* mig generated code is placed under mac directory

Makefile output has been diff-ed with previous state
to ensure that same flags are passed across the supported
archs.