### PR TITLE
Stackhash signatures blacklist

### DIFF
--- a/common.h
+++ b/common.h
@@ -80,6 +80,9 @@ typedef struct {
     char *externalCommand;
     const char *dictionaryFile;
     const char **dictionary;
+    const char *blacklistFile;
+    uint64_t *blacklist;
+    size_t blacklistCnt;
     long tmOut;
     size_t dictionaryCnt;
     size_t mutationsMax;
@@ -98,6 +101,7 @@ typedef struct {
     size_t mutationsCnt;
     size_t crashesCnt;
     size_t uniqueCrashesCnt;
+    size_t blCrashesCnt;
     size_t timeoutedCnt;
 
     /* For the linux/ code */

--- a/display.c
+++ b/display.c
@@ -95,9 +95,11 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
     display_put("Execs per second: " ESC_BOLD "%zu" ESC_RESET " (avg: " ESC_BOLD "%zu" ESC_RESET
                 ")\n", exec_per_sec, elapsed ? (curr_exec_cnt / elapsed) : 0);
 
-    display_put("Crashes: " ESC_BOLD "%zu" ESC_RESET " (unique: " ESC_BOLD "%zu" ESC_RESET ") \n",
+    display_put("Crashes: " ESC_BOLD "%zu" ESC_RESET " (unique: " ESC_BOLD "%zu" ESC_RESET
+                ", blacklist: " ESC_BOLD "%zu" ESC_RESET ") \n",
                 __sync_fetch_and_add(&hfuzz->crashesCnt, 0UL),
-                __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 0UL));
+                __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 0UL),
+                __sync_fetch_and_add(&hfuzz->blCrashesCnt, 0UL));
     display_put("Timeouts: " ESC_BOLD "%zu" ESC_RESET "\n",
                 __sync_fetch_and_add(&hfuzz->timeoutedCnt, 0UL));
 

--- a/files.c
+++ b/files.c
@@ -448,8 +448,8 @@ bool files_parseBlacklist(honggfuzz_t * hfuzz)
         hfuzz->blacklistCnt += 1;
     }
 
-    if (hfuzz->blacklistCnt > 1) {
-        LOGMSG(l_INFO, "Loaded %zu stack hashes from the blacklist file", hfuzz->blacklistCnt);
+    if (hfuzz->blacklistCnt > 0) {
+        LOGMSG(l_INFO, "Loaded %zu stack hash(es) from the blacklist file", hfuzz->blacklistCnt);
     } else {
         LOGMSG(l_FATAL, "Empty stack hashes blacklist file '%s'", hfuzz->blacklistFile);
     }

--- a/files.c
+++ b/files.c
@@ -420,7 +420,7 @@ bool files_parseBlacklist(honggfuzz_t * hfuzz)
     for (;;) {
         char *lineptr = NULL;
         size_t n = 0;
-        if (getdelim(&lineptr, &n, '\r', fBl) == -1) {
+        if (getline(&lineptr, &n, fBl) == -1) {
             break;
         }
         if ((hfuzz->blacklist =

--- a/files.c
+++ b/files.c
@@ -435,7 +435,6 @@ bool files_parseBlacklist(honggfuzz_t * hfuzz)
 
         hfuzz->blacklist[hfuzz->blacklistCnt] = strtoull(lineptr, 0, 16);
         LOGMSG(l_DEBUG, "Blacklist: loaded '%llu'", hfuzz->blacklist[hfuzz->blacklistCnt]);
-        hfuzz->blacklistCnt += 1;
 
         // Verify entries are sorted so we can use interpolation search
         if (hfuzz->blacklistCnt > 1) {
@@ -446,6 +445,7 @@ bool files_parseBlacklist(honggfuzz_t * hfuzz)
                 return false;
             }
         }
+        hfuzz->blacklistCnt += 1;
     }
 
     if (hfuzz->blacklistCnt > 1) {

--- a/files.c
+++ b/files.c
@@ -408,3 +408,34 @@ bool files_copyFile(const char *source, const char *destination, bool * dstExist
     close(outFD);
     return true;
 }
+
+bool files_parseBlacklist(honggfuzz_t * hfuzz)
+{
+    FILE *fBl = fopen(hfuzz->blacklistFile, "rb");
+    if (fBl == NULL) {
+        LOGMSG_P(l_ERROR, "Couldn't open '%s' - R/O mode", hfuzz->blacklistFile);
+        return false;
+    }
+
+    for (;;) {
+        char *lineptr = NULL;
+        size_t n = 0;
+        if (getdelim(&lineptr, &n, '\r', fBl) == -1) {
+            break;
+        }
+        if ((hfuzz->blacklist =
+             realloc(hfuzz->blacklist,
+                     (hfuzz->blacklistCnt + 1) * sizeof(hfuzz->blacklist[0]))) == NULL) {
+            LOGMSG_P(l_ERROR, "realloc failed (sz=%zu)",
+                     (hfuzz->blacklistCnt + 1) * sizeof(hfuzz->blacklist[0]));
+            fclose(fBl);
+            return false;
+        }
+        hfuzz->blacklist[hfuzz->blacklistCnt] = strtoull(lineptr, 0, 16);
+        LOGMSG(l_DEBUG, "Blacklist: loaded '%llu'", hfuzz->blacklist[hfuzz->blacklistCnt]);
+        hfuzz->blacklistCnt += 1;
+    }
+    LOGMSG(l_INFO, "Loaded %zu stack hashes from the blacklist file", hfuzz->blacklistCnt);
+    fclose(fBl);
+    return true;
+}

--- a/files.h
+++ b/files.h
@@ -49,4 +49,6 @@ extern bool files_parseDictionary(honggfuzz_t * hfuzz);
 
 extern bool files_copyFile(const char *source, const char *destination, bool * dstExists);
 
+bool files_parseBlacklist(honggfuzz_t * hfuzz);
+
 #endif

--- a/fuzz.c
+++ b/fuzz.c
@@ -442,6 +442,12 @@ void fuzz_main(honggfuzz_t * hfuzz)
 
     free(hfuzz->files);
     free(hfuzz->dynamicFileBest);
+    if (hfuzz->dictionary) {
+        free(hfuzz->dictionary);
+    }
+    if (hfuzz->blacklist) {
+        free(hfuzz->blacklist);
+    }
 
     _exit(EXIT_SUCCESS);
 }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -73,6 +73,7 @@ static void usage(bool exit_success)
            "            (default: current '.')\n"
            " [" AB "-r val" AC "] : flip rate, (default: '" AB "0.001" AC "')\n"
            " [" AB "-w val" AC "] : wordlist, (default: empty) [tokens delimited by NUL-bytes]\n"
+           " [" AB "-B val" AC "] : stackhashes blacklist file (one entry per line)\n"      
            " [" AB "-c val" AC "] : external command modifying the input corpus of files,\n"
            "            instead of -r/-m (default: " AB "none" AC ")\n"
            " [" AB "-t val" AC "] : timeout (in secs), (default: '" AB "3" AC "' [0 - no timeout])\n"
@@ -148,6 +149,9 @@ int main(int argc, char **argv)
         .dictionaryFile = NULL,
         .dictionary = NULL,
         .dictionaryCnt = 0,
+        .blacklistFile = NULL,
+        .blacklistCnt = 0,
+        .blacklist = NULL,
         .maxFileSz = (1024 * 1024),
         .tmOut = 3,
         .mutationsMax = 0,
@@ -165,6 +169,7 @@ int main(int argc, char **argv)
         .mutationsCnt = 0,
         .crashesCnt = 0,
         .uniqueCrashesCnt = 0,
+        .blCrashesCnt = 0,
         .timeoutedCnt = 0,
 
         .dynFileMethod = _HF_DYNFILE_NONE,
@@ -189,7 +194,7 @@ int main(int argc, char **argv)
     }
 
     for (;;) {
-        c = getopt(argc, argv, "-?hqvsuf:d:e:W:r:c:F:D:t:a:R:n:N:l:p:g:o:E:w:L:");
+        c = getopt(argc, argv, "-?hqvsuf:d:e:W:r:c:F:D:t:a:R:n:N:l:p:g:o:E:w:B:L:");
         if (c < 0)
             break;
 
@@ -289,6 +294,9 @@ int main(int argc, char **argv)
         case 'w':
             hfuzz.dictionaryFile = optarg;
             break;
+        case 'B':
+            hfuzz.blacklistFile = optarg;
+            break;
         case 'L':
             switch (optarg[0]) {
             case 'R':
@@ -360,6 +368,10 @@ int main(int argc, char **argv)
 
     if (hfuzz.dictionaryFile && (files_parseDictionary(&hfuzz) == false)) {
         LOGMSG(l_FATAL, "Couldn't parse dictionary file ('%s')", hfuzz.dictionaryFile);
+    }
+
+    if (hfuzz.blacklistFile && (files_parseBlacklist(&hfuzz) == false)) {
+        LOGMSG(l_FATAL, "Couldn't parse stackhash blacklist file ('%s')", hfuzz.blacklistFile);
     }
 
     /*

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -746,6 +746,16 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
      */
     arch_hashCallstack(fuzzer, funcs, funcCnt);
 
+    /* 
+     * Check if stackhash is blacklisted
+     */
+    if (hfuzz->blacklist
+        && (fastArray64Search(hfuzz->blacklist, hfuzz->blacklistCnt, fuzzer->backtrace) != -1)) {
+        LOGMSG(l_INFO, "Blacklisted stack hash '%" PRIx64 "', skipping", fuzzer->backtrace);
+        __sync_fetch_and_add(&hfuzz->blCrashesCnt, 1UL);
+        return;
+    }
+
     char newname[PATH_MAX];
     if (hfuzz->saveUnique) {
         snprintf(newname, sizeof(newname),

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -221,6 +221,16 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
      */
     __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
 
+    /* 
+     * Check if stackhash is blacklisted
+     */
+    if (hfuzz->blacklist
+        && (fastArray64Search(hfuzz->blacklist, hfuzz->blacklistCnt, fuzzer->backtrace) != -1)) {
+        LOGMSG(l_INFO, "Blacklisted stack hash '%" PRIx64 "', skipping", fuzzer->backtrace);
+        __sync_fetch_and_add(&hfuzz->blCrashesCnt, 1UL);
+        return true;
+    }
+
     bool dstFileExists = false;
     if (files_copyFile(fuzzer->fileName, newname, &dstFileExists)) {
         LOGMSG(l_INFO, "Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName, newname);

--- a/tools/createStackBlacklist.sh
+++ b/tools/createStackBlacklist.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env sh
+#
+#   honggfuzz stackhash blacklist file create script
+#   -----------------------------------------
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -e # fail on unhandled error
+set -u # fail on undefined variable
+#set -x # debug
+
+readonly tmpFile=$(pwd)/.hf.bl.txt
+declare -a sysTools=("perl" "cut" "sort" "paste" "wc" "tr" "cat")
+
+usage() {
+    echo "  Usage: $(basename $0) [options]"
+    echo "    OPTIONS:"
+    echo "      -i|--input  (mandatory): input crash(es) directory / file"
+    echo "      -o|--output (mandatory): output file to save found hashes (merge if exists)"
+    echo "      -e|--ext    (mandatory): file extension of fuzzer files (e.g. fuzz)"
+    echo "      -a|--arch   (mandatory): arch fuzzer have run against ('MAC' or 'LINUX')"
+    exit 1
+}
+
+command_exists () {
+    type "$1" &> /dev/null ;
+}
+
+# Check that system tools exist
+for i in "${sysTools[@]}"
+do
+  if ! command_exists $i; then
+    echo "[-] '$i' command not found"
+    exit 1
+  fi
+done
+
+INPUT_DIR=""
+OUTPUT_FILE=""
+FILE_EXT=""
+ARCH=""
+
+while [[ $# > 1 ]]
+do
+  arg="$1"
+  case $arg in
+    -i|--input)
+      INPUT_DIR="$2"
+      shift
+      ;;
+    -o|--output)
+      OUTPUT_FILE="$2"
+      shift
+      ;;
+    -e|--ext)
+      FILE_EXT="$2"
+      shift
+      ;;
+    -a|--arch)
+      ARCH="$2"
+      shift
+      ;;
+    *)
+      echo "[-] Invalid argument '$1'"
+      usage
+      ;;
+  esac
+  shift
+done
+
+if [[ "$INPUT_DIR" == "" || ! -e "$INPUT_DIR" ]]; then
+  echo "[-] Missing or invalid input directory"
+  usage
+fi
+
+if [[ "$OUTPUT_FILE" == "" ]]; then
+  echo "[-] Missing output file"
+  usage
+fi
+
+if [[ "$FILE_EXT" == "" ]]; then
+  echo "[-] Missing file extension"
+  usage
+fi
+
+if [[ "$ARCH" != "MAC" && "$ARCH" != "LINUX" ]]; then
+  echo "[-] Invlid architecture, expecting 'MAC' or 'LINUX'"
+  usage
+fi
+
+if [[ "$ARCH" == "LINUX" ]]; then
+  STACKHASH_FIELD=5
+elif [[ "$ARCH" == "MAC" ]]; then
+  STACKHASH_FIELD=6
+else
+  echo "[-] Unsupported architecture"
+  exit 1
+fi
+
+# save old data
+if [ -f $OUTPUT_FILE ]; then
+  cat $OUTPUT_FILE > $tmpFile
+  oldCount=$(cat $OUTPUT_FILE | wc -l | tr -d " ")
+else
+  oldCount=0
+fi
+
+echo "[*] Processing files from '$INPUT_DIR' ..."
+find $INPUT_DIR -type f -iname "*.$FILE_EXT" | while read -r FILE
+do
+  fileName=$(basename $FILE)
+  if ! echo $fileName | grep -qF ".STACK."; then
+    echo "[!] Skipping '$FILE'"
+    continue
+  fi
+  stackHash=$(echo $fileName | cut -d '.' -f$STACKHASH_FIELD)
+
+  # We don't want to lose crashes where unwinder failed
+  if [[ "$stackHash" != "0" ]]; then
+    echo $stackHash >> $tmpFile
+  fi
+done
+
+# sort hex values
+perl -lpe '$_=hex' $tmpFile | \
+paste -d" " - $tmpFile  | sort -nu | cut -d" " -f 2- \
+> $OUTPUT_FILE
+
+entries=$(cat $OUTPUT_FILE | wc -l | tr -d " ")
+echo "[*] $OUTPUT_FILE contains $entries blacklisted stack hashes"
+
+rm $tmpFile

--- a/util.c
+++ b/util.c
@@ -266,3 +266,28 @@ extern void MX_UNLOCK(pthread_mutex_t * mutex)
         LOGMSG_P(l_FATAL, "pthread_mutex_unlock(%p)", mutex);
     }
 }
+
+extern int64_t fastArray64Search(uint64_t * array, size_t arraySz, uint64_t key)
+{
+    size_t low = 0;
+    size_t high = arraySz - 1;
+    size_t mid;
+
+    while (array[high] != array[low] && key >= array[low] && key <= array[high]) {
+        mid = low + (key - array[low]) * ((high - low) / (array[high] - array[low]));
+
+        if (array[mid] < key) {
+            low = mid + 1;
+        } else if (key < array[mid]) {
+            high = mid - 1;
+        } else {
+            return mid;
+        }
+    }
+
+    if (key == array[low]) {
+        return low;
+    } else {
+        return -1;
+    }
+}

--- a/util.h
+++ b/util.h
@@ -55,4 +55,6 @@ extern uint32_t util_ToFromLE32(uint32_t val);
 extern void MX_LOCK(pthread_mutex_t * mutex);
 extern void MX_UNLOCK(pthread_mutex_t * mutex);
 
+extern int64_t fastArray64Search(uint64_t * array, size_t arraySz, uint64_t key);
+
 #endif


### PR DESCRIPTION
### Description
The idea is to skip during fuzzing time already analyzed crashes without having to transfer entire crash files between target workspaces. Additionally, same vulnerable library might be loaded in different addresses (even with ASLR disabled) resulting into noise duplicates (due to PC or ADDR) that can be avoided with stack hash blacklists.

### Implementation
* New calling argument (-B) exported so that user can provide a file with blacklisted stack hashes (hex format one per line). Input file must be sorted (using the provided bash script is strongly recommended).
* File is parsed during init phase and stored in heap
* File is checked for being sorted and not empty
* When crash is detected for MAC & LINUX arch, stack hash is checked against the blacklist using a relatively fast interpolation search against the heap array.
* Stack hash blacklist is working independently of the unique crashes feature.

### Helper bash script
* tools/createStackBlacklist.sh script can be used post-campaign (after initial analysis) to extract stack hashes from crash files (following HF convention) and create a sorted blacklist file. Same script can be also used to sort existing blacklist files.
* Due to created filenames between Linux PTRACE arch and MAC not following the same name conventions, bash script takes as an argument the architecture name that fuzzer has run against. In order to be more flexible it would a good idea to consider following the same naming conventions for crashes (unique and non-unique) for both Linux & MAC.