### PR TITLE
log + cmd bug fixes

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -95,7 +95,7 @@ endif
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := honggfuzz
-LOCAL_SRC_FILES := honggfuzz.c display.c log.c files.c fuzz.c report.c mangle.c util.c
+LOCAL_SRC_FILES := honggfuzz.c cmdline.c display.c log.c files.c fuzz.c report.c mangle.c util.c
 LOCAL_CFLAGS := -std=c11 -I. \
     -D_GNU_SOURCE \
     -Wall -Wextra -Wno-initializer-overrides -Wno-override-init \

--- a/cmdline.c
+++ b/cmdline.c
@@ -25,17 +25,11 @@
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
-#include <grp.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <pwd.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
-#include <sys/personality.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include "common.h"
@@ -85,8 +79,9 @@ static void cmdlineHelp(const char *pname, struct custom_option *opts)
              " Run the binary over a mutated file chosen from the directory:\n"
              AB "  " PROG_NAME " -f input_dir -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER AC "\n"
              " As above, provide input over STDIN:\n"
-             AB "  " PROG_NAME " -f input_dir -s -- /usr/bin/djpeg\n" AC
+             AB "  " PROG_NAME " -f input_dir -s -- /usr/bin/djpeg\n" AC);
 #if defined(_HF_ARCH_LINUX)
+    LOG_HELP("%s",
              " Run the binary over a dynamic file, maximize total no. of instructions:\n"
              AB "  " PROG_NAME " --linux_perf_instr -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER
              AC "\n" " Run the binary over a dynamic file, maximize total no. of branches:\n" AB
@@ -96,10 +91,10 @@ static void cmdlineHelp(const char *pname, struct custom_option *opts)
              "\n" " Run the binary over a dynamic file, maximize unique branches (edges):\n" AB "  "
              PROG_NAME " --linux_perf_ip_addr -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER AC "\n"
              " Run the binary over a dynamic file, maximize custom counters (experimental):\n" AB
-             "  " PROG_NAME " --linux_perf_custom -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER AC
-             "\n"
+             "  " PROG_NAME " --linux_perf_custom -- /usr/bin/tiffinfo -D " _HF_FILE_PLACEHOLDER
+             AC);
 #endif                          /* defined(_HF_ARCH_LINUX) */
-        );
+    LOG_HELP("\n");
 }
 
 static void cmdlineUsage(const char *pname, struct custom_option *opts)
@@ -397,7 +392,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
     }
 
     LOG_I("inputFile '%s', nullifyStdio: %s, fuzzStdin: %s, saveUnique: %s, flipRate: %lf, "
-          "externalCommand: '%s', tmOut: %ld, mutationsMax: %ld, threadsMax: %ld, fileExtn '%s', ignoreAddr: %p, "
+          "externalCommand: '%s', tmOut: %ld, mutationsMax: %zu, threadsMax: %zu, fileExtn '%s', ignoreAddr: %p, "
           "memoryLimit: 0x%" PRIx64 "(MiB), fuzzExe: '%s', fuzzedPid: %d",
           hfuzz->inputFile,
           cmdlineYesNo(hfuzz->nullifyStdio), cmdlineYesNo(hfuzz->fuzzStdin),

--- a/files.c
+++ b/files.c
@@ -55,7 +55,7 @@ size_t files_readFileToBufMax(char *fileName, uint8_t * buf, size_t fileMaxSz)
     }
 
     if (st.st_size > (off_t) fileMaxSz) {
-        LOG_E("File '%s' size to big (%zu > %" PRId64 ")", fileName, (int64_t) st.st_size,
+        LOG_E("File '%s' size to big (%zu > %zu)", fileName, (size_t) st.st_size,
               fileMaxSz);
         close(fd);
         return 0UL;
@@ -375,7 +375,7 @@ bool files_copyFile(const char *source, const char *destination, bool * dstExist
 
     uint8_t *inFileBuf = malloc(inSt.st_size);
     if (!inFileBuf) {
-        PLOG_E("malloc(%zu) failed", inSt.st_size);
+        PLOG_E("malloc(%zu) failed", (size_t) inSt.st_size);
         close(inFD);
         close(outFD);
         return false;
@@ -390,7 +390,7 @@ bool files_copyFile(const char *source, const char *destination, bool * dstExist
     }
 
     if (files_writeToFd(outFD, inFileBuf, inSt.st_size) == false) {
-        PLOG_E("Couldn't write '%zu' bytes to file '%s' (fd='%d')", inSt.st_size,
+        PLOG_E("Couldn't write '%zu' bytes to file '%s' (fd='%d')", (size_t) inSt.st_size,
                destination, outFD);
         free(inFileBuf);
         close(inFD);

--- a/linux/perf.c
+++ b/linux/perf.c
@@ -267,7 +267,7 @@ static bool arch_perfOpen(pid_t pid, dynFileMethod_t method, int *perfFd)
                      MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
     if (perfBloom == MAP_FAILED) {
         perfBloom = NULL;
-        PLOG_E("mmap(size=%zu) failed", _HF_PERF_BLOOM_SZ);
+        PLOG_E("mmap(size=%zu) failed", (size_t) _HF_PERF_BLOOM_SZ);
     }
 
     perfMmapBuf =

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -811,14 +811,14 @@ static void arch_ptraceEvent(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, int status,
             }
 
             if (WIFEXITED(event_msg)) {
-                LOG_D("PID: %d exited with exit_code: %d", pid, WEXITSTATUS(event_msg));
-                if (WEXITSTATUS(event_msg) == HF_MSAN_EXIT_CODE) {
+                LOG_D("PID: %d exited with exit_code: %lu", pid, WEXITSTATUS(event_msg));
+                if (WEXITSTATUS(event_msg) == (unsigned long) HF_MSAN_EXIT_CODE) {
                     arch_ptraceSaveData(hfuzz, pid, fuzzer);
                 }
             } else if (WIFSIGNALED(event_msg)) {
-                LOG_D("PID: %d terminated with signal: %d", pid, WTERMSIG(event_msg));
+                LOG_D("PID: %d terminated with signal: %lu", pid, WTERMSIG(event_msg));
             } else {
-                LOG_D("PID: %d exited with unknown status: %ld", pid, event_msg);
+                LOG_D("PID: %d exited with unknown status: %lu", pid, event_msg);
             }
         }
         break;

--- a/log.c
+++ b/log.c
@@ -30,9 +30,15 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
+
+#if defined(_HF_ARCH_LINUX)
+#include <sys/syscall.h>
+#define __hf_pid()      (pid_t) syscall(__NR_gettid)
+#else                           /* defined(_HF_ARCH_LINUX) */
+#define __hf_pid()      getpid()
+#endif                          /* defined(_HF_ARCH_LINUX) */
 
 static int log_fd = STDERR_FILENO;
 static bool log_fd_isatty = true;
@@ -98,8 +104,8 @@ void logLog(enum llevel_t ll, const char *fn, int ln, bool perr, const char *fmt
         dprintf(log_fd, "%s", logLevels[ll].prefix);
     }
     if (logLevels[ll].print_funcline) {
-        dprintf(log_fd, "[%s][%s][%ld] %s():%d ", timestr, logLevels[ll].descr,
-                syscall(__NR_getpid), fn, ln);
+        dprintf(log_fd, "[%s][%s][%d] %s():%d ", timestr, logLevels[ll].descr,
+                __hf_pid(), fn, ln);
     }
 
     va_list args;

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -668,7 +668,7 @@ uint64_t hash_callstack(thread_port_t thread,
         pos++;
     }
 
-    LOG_D("Callstack hash %u", hash);
+    LOG_D("Callstack hash %llu", hash);
 
     [_crashReport release];
     [pool drain];


### PR DESCRIPTION
Small fixes spotted when compiling for MAC & Android.

* Print-out format fixes. Casts have been introduced at some places to clarify the matching type and satisfy tested compilers.
* Update Android makefile with new cmd parsing component.
* Wrap getpid() with arch defines, enabling syscall only for LINUX arch.
* Clean-up unused headers in cmdline.c
* Split LOG_HELP print messages since clang was complaining:
cmdline.c:88:2: error: embedding a directive within macro arguments has undefined behavior [-Werror,-Wembedded-directive]

