### PR TITLE
Verifier optimizations

### DIFF
--- a/fuzz.c
+++ b/fuzz.c
@@ -106,6 +106,13 @@ static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, 
 
     MX_UNLOCK(&hfuzz->dynamicFile_mutex);
 
+    /* 
+     * if flip rate is 0.0, early abort file mangling. This will leave perf counters
+     * with values equal to dry runs against input corpus.
+     */
+    if (hfuzz->flipRate != 0.0L) {
+        goto skipMangling;
+    }
     /* The first pass should be on an empty/initial file */
     if (hfuzz->hwCnts.cpuInstrCnt > 0 || hfuzz->hwCnts.cpuBranchCnt > 0 || hfuzz->hwCnts.pcCnt > 0
         || hfuzz->hwCnts.pathCnt > 0 || hfuzz->hwCnts.customCnt > 0) {
@@ -113,6 +120,7 @@ static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, 
         mangle_mangleContent(hfuzz, fuzzer->dynamicFile, fuzzer->dynamicFileSz);
     }
 
+ skipMangling:
     if (files_writeBufToFile
         (fuzzer->fileName, fuzzer->dynamicFile, fuzzer->dynamicFileSz,
          O_WRONLY | O_CREAT | O_EXCL | O_TRUNC) == false) {
@@ -132,8 +140,11 @@ static bool fuzz_prepareFile(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, int rnd_ind
         return false;
     }
 
-    mangle_Resize(hfuzz, fuzzer->dynamicFile, &fileSz);
-    mangle_mangleContent(hfuzz, fuzzer->dynamicFile, fileSz);
+    /* If flip rate is 0.0, early abort file mangling */
+    if (hfuzz->flipRate != 0.0L) {
+        mangle_Resize(hfuzz, fuzzer->dynamicFile, &fileSz);
+        mangle_mangleContent(hfuzz, fuzzer->dynamicFile, fileSz);
+    }
 
     if (files_writeBufToFile
         (fuzzer->fileName, fuzzer->dynamicFile, fileSz, O_WRONLY | O_CREAT | O_EXCL) == false) {

--- a/fuzz.c
+++ b/fuzz.c
@@ -333,7 +333,7 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz)
         LOG_F("malloc(%zu) failed", hfuzz->maxFileSz);
     }
 
-    int rnd_index = util_rndGet(0, hfuzz->fileCnt - 1);
+    size_t rnd_index = util_rndGet(0, hfuzz->fileCnt - 1);
 
     /* If dry run mode, pick the next file and not a random one */
     if (hfuzz->flipRate == 0.0L && hfuzz->useVerifier) {

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -788,7 +788,7 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
      */
     if (fuzzer->crashFileName) {
         LOG_D("Multiple crashes detected from worker against attached tids group");
-        
+
         /*
          * If stackhashes match, don't re-analyze. This will avoid duplicates
          * and prevent verifier from running multiple passes. Depth of check is

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -825,7 +825,8 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
 
     /* If dry run mode, copy file with same name into workspace */
     if (hfuzz->flipRate == 0.0L && hfuzz->useVerifier) {
-        snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName), "%s", fuzzer->origFileName);
+        snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName), "%s/%s",
+                 hfuzz->workDir, fuzzer->origFileName);
     } else if (hfuzz->saveUnique) {
         snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
                  "%s/%s.PC.%" REG_PM ".STACK.%" PRIx64 ".CODE.%d.ADDR.%p.INSTR.%s.%s",

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -195,7 +195,8 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
 
     /* If dry run mode, copy file with same name into workspace */
     if (hfuzz->flipRate == 0.0L && hfuzz->useVerifier) {
-        snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName), "%s", fuzzer->origFileName);
+        snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName), "%s/%s",
+                 hfuzz->workDir, fuzzer->origFileName);
     } else if (hfuzz->saveUnique) {
         snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
                  "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s",

--- a/mangle.c
+++ b/mangle.c
@@ -359,10 +359,6 @@ void mangle_mangleContent(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz)
     };
     /*  *INDENT-ON* */
 
-    /* if -r 0.0 then just return */
-    if (hfuzz->flipRate == 0.0L) {
-        return;
-    }
     /*
      * Minimal number of changes is 1
      */


### PR DESCRIPTION
* Linux: ptrace crash detection optimizations
  * Add detection logic for multiple tid crashes against the same target from same worker. Detection logic goes up to depth 1. Proved useful for targets where multiple threads process the same data for different reasons and have identical crash backtraces from helper functions.
  * Move crashes counter after initial checks that don't save new crash triggers, to have an accurate value in display.
 * Remove Android hack. Recently refactored ptrace backend doesn't require manual signal jamming in case of Android. ptrace logic ensures that target is monitored at all time preventing debuggerd from attaching to target (will fail at attach syscall). Also previous bullet ensures that no duplicates are analyzed for same master thread.


* Early mangle abort for 0 flip rate
  * Avoid running mangling routines if 0.0 flip rate. This will avoid the overhead of mangle_Resize until mangle content reaches the old 0.0 check.
  * If dynamic file prepare, preserve the perf counters update that equal to dry runs against input corpus. Might prove useful for comparing efficiency against original seeds.


* Verifier dry run should respect workdir
  * If dry run (verifier + 0.0 flip rate) copy original files under workspace directory if verified successfully.