### PR TITLE
LINUX: callstack hash, handle zero frames unwinder error

### DIFF
--- a/fuzz.c
+++ b/fuzz.c
@@ -439,7 +439,7 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz)
         MX_UNLOCK(&hfuzz->dynamicFile_mutex);
     }
 
-    if (hfuzz->useVerifier && (fuzzer.crashFileName[0] != 0)) {
+    if (hfuzz->useVerifier && (fuzzer.crashFileName[0] != 0) && fuzzer.backtrace) {
         if (!fuzz_runVerifier(hfuzz, &fuzzer)) {
             LOG_I("Failed to verify %s", fuzzer.crashFileName);
         }


### PR DESCRIPTION
If unwinder failed (zero frames extracted), try to fail over using PC extracted from PTRACE GETREGS. If PC not zero manually create a major frame so that failover can fit into single frame handling and benefit
whenever possible. If PC is zero, disable uniqueness flag for this crash to prevent losing crashes.

Upgrade verifier threads analyzeData too to handle this case.