### PR TITLE
Annotate unused vars

### DIFF
--- a/common.h
+++ b/common.h
@@ -31,6 +31,10 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#ifndef UNUSED
+#define UNUSED __attribute__((unused))
+#endif
+
 #define PROG_NAME "honggfuzz"
 #define PROG_VERSION "0.6rc"
 #define PROG_AUTHORS "Robert Swiecki <swiecki@google.com> et al.,\nCopyright 2010-2015 by Google Inc. All Rights Reserved."

--- a/fuzz.c
+++ b/fuzz.c
@@ -75,8 +75,6 @@ static void fuzz_getFileName(honggfuzz_t * hfuzz, char *fileName)
     snprintf(fileName, PATH_MAX, "%s/.honggfuzz.%d.%lu.%llx.%s", hfuzz->workDir, (int)getpid(),
              (unsigned long int)tv.tv_sec, (unsigned long long int)util_rndGet(0, 1ULL << 62),
              hfuzz->fileExtn);
-
-    return;
 }
 
 static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, int rnd_index)
@@ -447,7 +445,6 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz)
 
     report_Report(hfuzz, fuzzer.report);
     free(fuzzer.dynamicFile);
-
 }
 
 static void *fuzz_threadNew(void *arg)

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -190,17 +190,10 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
     return false;
 }
 
-static void arch_sigFunc(int signo, siginfo_t * si, void *dummy)
+static void arch_sigFunc(int signo, siginfo_t * si UNUSED, void *dummy UNUSED)
 {
     if (signo != SIGALRM) {
         LOG_E("Signal != SIGALRM (%d)", signo);
-    }
-    return;
-    if (si == NULL) {
-        return;
-    }
-    if (dummy == NULL) {
-        return;
     }
 }
 
@@ -335,7 +328,6 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     }
     arch_removeTimer(&timerid);
     arch_perfAnalyze(hfuzz, fuzzer, &perfFds);
-    return;
 }
 
 bool arch_archInit(honggfuzz_t * hfuzz)

--- a/linux/bfd.c
+++ b/linux/bfd.c
@@ -90,7 +90,6 @@ static void arch_bfdDestroy(bfd_t * bfdParams)
     if (bfdParams->bfdh) {
         bfd_close_all_done(bfdParams->bfdh);
     }
-    return;
 }
 
 void arch_bfdResolveSyms(pid_t pid, funcs_t * funcs, size_t num)
@@ -133,7 +132,6 @@ void arch_bfdResolveSyms(pid_t pid, funcs_t * funcs, size_t num)
     arch_bfdDestroy(&bfdParams);
 
     while (pthread_mutex_unlock(&arch_bfd_mutex)) ;
-    return;
 }
 
 static int arch_bfdFPrintF(void *buf, const char *fmt, ...)
@@ -190,5 +188,4 @@ void arch_bfdDisasm(pid_t pid, uint8_t * mem, size_t size, char *instr)
     bfdh ? bfd_close_all_done(bfdh) : 0;
 
     while (pthread_mutex_unlock(&arch_bfd_mutex)) ;
-    return;
 }

--- a/linux/perf.c
+++ b/linux/perf.c
@@ -436,6 +436,4 @@ void arch_perfAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, perfFd_t * perfFds
     fuzzer->hwCnts.cpuBranchCnt = branchCount;
     fuzzer->hwCnts.pcCnt = pathCount;
     fuzzer->hwCnts.pathCnt = edgeCount;
-
-    return;
 }

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -405,10 +405,7 @@ static size_t arch_getProcMem(pid_t pid, uint8_t * buf, size_t len, REG_TYPE pc)
     return memsz;
 }
 
-// Non i386 / x86_64 ISA fail build due to unused pid argument
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-void arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid, uint64_t * cnt)
+void arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid UNUSED, uint64_t * cnt UNUSED)
 {
     if ((hfuzz->dynFileMethod & _HF_DYNFILE_CUSTOM) == 0) {
         return;
@@ -456,8 +453,6 @@ void arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid, uint64_t * cnt)
     LOG_W("Unknown registers structure size: '%zd'", pt_iov.iov_len);
 #endif                          /* defined(__i386__) || defined(__x86_64__) */
 }
-
-#pragma GCC diagnostic pop      /* ignored "-Wunused-parameter" */
 
 static size_t arch_getPC(pid_t pid, REG_TYPE * pc, REG_TYPE * status_reg)
 {
@@ -954,7 +949,6 @@ static void arch_ptraceEvent(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, int status,
     }
 
     ptrace(PT_CONTINUE, pid, 0, 0);
-    return;
 }
 
 void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * fuzzer)
@@ -1004,7 +998,6 @@ void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * f
     }
 
     abort();                    /* NOTREACHED */
-    return;
 }
 
 static bool arch_listThreads(int tasks[], size_t thrSz, int pid)

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -249,12 +249,9 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
     return true;
 }
 
-pid_t arch_fork(honggfuzz_t * hfuzz)
+pid_t arch_fork(honggfuzz_t * hfuzz UNUSED)
 {
     return fork();
-    if (hfuzz == NULL) {
-        return -1;
-    }
 }
 
 bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)

--- a/mangle.c
+++ b/mangle.c
@@ -46,45 +46,26 @@ static inline void mangle_Overwrite(uint8_t * dst, const uint8_t * src, size_t d
     memcpy(&dst[off], src, sz);
 }
 
-static void mangle_Byte(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_Byte(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz UNUSED, size_t off)
 {
     buf[off] = (uint8_t) util_rndGet(0, UINT8_MAX);
-    return;
-    /* Ignore buffer size */
-    if (bufSz == 0) {
-        return;
-    }
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_Bytes(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_Bytes(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     uint32_t val = (uint32_t) util_rndGet(0, UINT32_MAX);
 
     /* Overwrite with random 2,3,4-byte values */
     size_t toCopy = util_rndGet(2, 4);
     mangle_Overwrite(buf, (uint8_t *) & val, bufSz, off, toCopy);
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_Bit(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_Bit(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz UNUSED, size_t off)
 {
     buf[off] ^= ((uint8_t) 1 << util_rndGet(0, 7));
-    return;
-    /* Ignore buffer size */
-    if (bufSz == 0) {
-        return;
-    }
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_Dictionary(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_Dictionary(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     if (hfuzz->dictionaryCnt == 0) {
         mangle_Bit(hfuzz, buf, bufSz, off);
@@ -94,12 +75,9 @@ static void mangle_Dictionary(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, 
     uint64_t choice = util_rndGet(0, hfuzz->dictionaryCnt - 1);
     mangle_Overwrite(buf, (uint8_t *) hfuzz->dictionary[choice], bufSz, off,
                      strlen(hfuzz->dictionary[choice]));
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_Magic(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_Magic(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     /*  *INDENT-OFF* */
     static const struct {
@@ -191,23 +169,17 @@ static void mangle_Magic(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_
 
     uint64_t choice = util_rndGet(0, ARRAYSIZE(mangleMagicVals) - 1);
     mangle_Overwrite(buf, mangleMagicVals[choice].val, bufSz, off, mangleMagicVals[choice].size);
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_MemSet(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_MemSet(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     uint64_t sz = util_rndGet(1, bufSz - off);
     int val = (int)util_rndGet(0, UINT8_MAX);
 
     memset(&buf[off], val, sz);
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_MemMove(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_MemMove(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     uint64_t mangleTo = util_rndGet(0, bufSz - 1);
     uint64_t mangleSzTo = bufSz - mangleTo;
@@ -216,21 +188,15 @@ static void mangle_MemMove(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, siz
     uint64_t mangleSz = mangleSzFrom < mangleSzTo ? mangleSzFrom : mangleSzTo;
 
     memmove(&buf[mangleTo], &buf[off], mangleSz);
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_Random(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_Random(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     uint64_t sz = util_rndGet(1, bufSz - off);
     util_rndBuf(&buf[off], sz);
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_AddSub(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_AddSub(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz, size_t off)
 {
     /* 1,2,4 */
     uint64_t varLen = 1ULL << util_rndGet(0, 2);
@@ -290,35 +256,18 @@ static void mangle_AddSub(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size
             break;
         }
     }
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_IncByte(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_IncByte(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz UNUSED,
+                           size_t off)
 {
     buf[off] += (uint8_t) 1UL;
-    return;
-    /* bufSz is unused */
-    if (bufSz == 0) {
-        return;
-    }
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
-static void mangle_DecByte(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz, size_t off)
+static void mangle_DecByte(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz UNUSED,
+                           size_t off)
 {
     buf[off] -= (uint8_t) 1UL;
-    return;
-    /* bufSz is unused */
-    if (bufSz == 0) {
-        return;
-    }
-    if (hfuzz == NULL) {
-        return;
-    }
 }
 
 void mangle_mangleContent(honggfuzz_t * hfuzz, uint8_t * buf, size_t bufSz)

--- a/mangle.c
+++ b/mangle.c
@@ -81,9 +81,9 @@ static void mangle_Magic(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufSz
 {
     /*  *INDENT-OFF* */
     static const struct {
-        const uint8_t const val[8];
+        const uint8_t val[8];
         const size_t size;
-    } const mangleMagicVals[] = {
+    } mangleMagicVals[] = {
         /* 1B - No endianness */
         { "\x00\x00\x00\x00\x00\x00\x00\x00", 1},
         { "\x01\x00\x00\x00\x00\x00\x00\x00", 1},

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -134,12 +134,9 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
     return true;
 }
 
-pid_t arch_fork(honggfuzz_t * hfuzz)
+pid_t arch_fork(honggfuzz_t * hfuzz UNUSED)
 {
     return fork();
-    if (hfuzz == NULL) {
-        return -1;
-    }
 }
 
 bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
@@ -265,10 +262,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     }
 }
 
-bool arch_archInit(honggfuzz_t * hfuzz)
+bool arch_archInit(honggfuzz_t * hfuzz UNUSED)
 {
-    if (hfuzz) {
-        return true;
-    }
     return true;
 }

--- a/report.c
+++ b/report.c
@@ -120,6 +120,4 @@ void report_Report(honggfuzz_t * hfuzz, char *s)
 
     dprintf(reportFD,
             "%s" "=====================================================================\n", s);
-
-    return;
 }

--- a/util.c
+++ b/util.c
@@ -94,8 +94,6 @@ void util_rndBuf(uint8_t * buf, size_t sz)
         x = (a * x + c);
         buf[i] = (uint8_t) (x & 0xFF);
     }
-
-    return;
 }
 
 int util_vssnprintf(char *str, size_t size, const char *format, va_list ap)
@@ -150,8 +148,6 @@ void util_nullifyStdio(void)
     if (fd > 2) {
         close(fd);
     }
-
-    return;
 }
 
 bool util_redirectStdin(char *inputFile)
@@ -191,7 +187,6 @@ void util_recoverStdio(void)
     if (fd > 2) {
         close(fd);
     }
-    return;
 }
 
 /*


### PR DESCRIPTION
Add UNUSED attribute macro and annotate unused variables across the codebase removing dead code that creates indexing noise.

Small clang fix for const struct array. Clang is not happy with duplicate const declarations. After commit applied it has been verified that magicValue array data are stored in expected .rodata & __TEXT,__const
for ELF (Linux & Android) & Mach-O accordingly.