### PR TITLE
Add sanitizer coverage feedback evolution support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ endif
 ANDROID_DEBUG_ENABLED ?= false
 ANDROID_APP_ABI       ?= armeabi-v7a
 ANDROID_API           ?= android-21
+ANDROID_NDK_TOOLCHAIN ?=
 NDK_BUILD_ARGS :=
 ifeq ($(ANDROID_DEBUG_ENABLED),true)
     NDK_BUILD_ARGS += V=1 NDK_DEBUG=1 APP_OPTIM=debug
@@ -174,7 +175,8 @@ depend:
 .PHONY: android
 android:
 	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./android/Android.mk \
-                  APP_PLATFORM=$(ANDROID_API) APP_ABI=$(ANDROID_APP_ABI) $(NDK_BUILD_ARGS)
+                  APP_PLATFORM=$(ANDROID_API) APP_ABI=$(ANDROID_APP_ABI) \
+                  NDK_TOOLCHAIN=$(ANDROID_NDK_TOOLCHAIN) $(NDK_BUILD_ARGS)
 
 
 # DO NOT DELETE

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 
 # Common for all architectures
 BIN := honggfuzz
-COMMON_CFLAGS := -D_GNU_SOURCE -Wall -Werror
+COMMON_CFLAGS := -D_GNU_SOURCE -Wall -Werror -Wframe-larger-than=51200
 COMMON_LDFLAGS := -lm
 COMMON_SRCS := honggfuzz.c cmdline.c display.c log.c files.c fuzz.c report.c mangle.c util.c
 INTERCEPTOR_SRCS := $(wildcard interceptor/*.c)

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -107,7 +107,7 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   LOCAL_C_INCLUDES := third_party/android/libunwind/include third_party/android/capstone/include
   LOCAL_STATIC_LIBRARIES := libunwind-arch libunwind libunwind-ptrace libunwind-dwarf-generic libcapstone
   LOCAL_CFLAGS += -D__HF_USE_CAPSTONE__
-  ARCH_SRCS := linux/arch.c linux/ptrace_utils.c linux/perf.c linux/unwind.c
+  ARCH_SRCS := linux/arch.c linux/ptrace_utils.c linux/perf.c linux/unwind.c linux/sancov.c
   ARCH := LINUX
   ifeq ($(ARCH_ABI),arm)
     LOCAL_CFLAGS += -DOPENSSL_ARMCAP_ABI='$(OPENSSL_ARMCAP_ABI)'

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -99,7 +99,8 @@ LOCAL_SRC_FILES := honggfuzz.c cmdline.c display.c log.c files.c fuzz.c report.c
 LOCAL_CFLAGS := -std=c11 -I. \
     -D_GNU_SOURCE \
     -Wall -Wextra -Wno-initializer-overrides -Wno-override-init \
-    -Wno-unknown-warning-option -Werror -funroll-loops -O2
+    -Wno-unknown-warning-option -Werror -funroll-loops -O2 \
+    -Wframe-larger-than=51200
 LOCAL_LDFLAGS := -lm
 
 ifeq ($(ANDROID_WITH_PTRACE),true)

--- a/cmdline.c
+++ b/cmdline.c
@@ -232,7 +232,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         {{"env", required_argument, NULL, 'E'}, "Pass this environment variable, can be used multiple times"},
 
 #if defined(_HF_ARCH_LINUX)
-        {{"sancov", no_argument, NULL, 'C'}, "Enable sanitizer coverage feedback (default: disabled)"},
+        {{"sancov", no_argument, NULL, 'C'}, "EXPERIMENTAL: Enable sanitizer coverage feedback (default: disabled)"},
         {{"linux_pid", required_argument, NULL, 'p'}, "[Linux] Attach to a pid (and its thread group)"},
         {{"linux_addr_low_limit", required_argument, NULL, 0x500}, "Address limit (from si.si_addr) below which crashes are not reported, (default: '0')"},
         {{"linux_keep_aslr", no_argument, NULL, 0x501}, "Don't disable ASLR randomization, might be useful with MSAN"},

--- a/cmdline.c
+++ b/cmdline.c
@@ -201,6 +201,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         .msanReportUMRS = false,
         .ignoreAddr = NULL,
         .useSanCov = false,
+        .dynFileIterExpire = _HF_MAX_DYNFILE_ITER,
     };
     /*  *INDENT-ON* */
 

--- a/cmdline.c
+++ b/cmdline.c
@@ -406,6 +406,13 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         LOG_E("The file extension contains the '/' character: '%s'", hfuzz->fileExtn);
         return false;
     }
+    
+    if (hfuzz->workDir[0] != '.') {
+        if (!files_exists(hfuzz->workDir)) {
+            LOG_E("Provided workspace directory '%s' doesn't exist", hfuzz->workDir);
+            return false;
+        }
+    }
 
     if (hfuzz->pid > 0) {
         LOG_I("PID=%d specified, lowering maximum number of concurrent threads to 1", hfuzz->pid);
@@ -413,7 +420,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
     }
 
     if (hfuzz->flipRate == 0.0L && hfuzz->useVerifier) {
-        LOG_I("Verifier enabled with 0.0flipRate, activating dry run mode");
+        LOG_I("Verifier enabled with 0.0 flipRate, activating dry run mode");
     }
 
     LOG_I("inputFile '%s', nullifyStdio: %s, fuzzStdin: %s, saveUnique: %s, flipRate: %lf, "

--- a/cmdline.c
+++ b/cmdline.c
@@ -428,7 +428,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         return false;
     }
 
-    if (hfuzz->workDir[0] != '.') {
+    if (hfuzz->workDir[0] != '.' || strlen(hfuzz->workDir) > 2) {
         if (!files_exists(hfuzz->workDir)) {
             LOG_E("Provided workspace directory '%s' doesn't exist", hfuzz->workDir);
             return false;

--- a/cmdline.c
+++ b/cmdline.c
@@ -34,6 +34,7 @@
 
 #include "common.h"
 #include "log.h"
+#include "files.h"
 
 #define AB ANSI_BOLD
 #define AC ANSI_CLEAR
@@ -190,12 +191,16 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
                    .pathCnt = 0ULL,
                    .customCnt = 0ULL,
                    },
+        .sanCovCnts = {
+                       .pcCnt = 0ULL,  
+                      },
         .dynamicCutOffAddr = ~(0ULL),
         .dynamicFile_mutex = PTHREAD_MUTEX_INITIALIZER,
 
         .disableRandomization = true,
         .msanReportUMRS = false,
         .ignoreAddr = NULL,
+        .useSanCov = false,
     };
     /*  *INDENT-ON* */
 
@@ -227,6 +232,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         {{"env", required_argument, NULL, 'E'}, "Pass this environment variable, can be used multiple times"},
 
 #if defined(_HF_ARCH_LINUX)
+        {{"sancov", no_argument, NULL, 'C'}, "Enable sanitizer coverage feedback (default: disabled)"},
         {{"linux_pid", required_argument, NULL, 'p'}, "[Linux] Attach to a pid (and its thread group)"},
         {{"linux_addr_low_limit", required_argument, NULL, 0x500}, "Address limit (from si.si_addr) below which crashes are not reported, (default: '0')"},
         {{"linux_keep_aslr", no_argument, NULL, 0x501}, "Don't disable ASLR randomization, might be useful with MSAN"},
@@ -251,7 +257,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
     const char *logfile = NULL;
     int opt_index = 0;
     for (;;) {
-        int c = getopt_long(argc, argv, "-?hqvVsuf:d:e:W:r:c:F:t:R:n:N:l:p:g:E:w:B:", opts,
+        int c = getopt_long(argc, argv, "-?hqvVsuf:d:e:W:r:c:F:t:R:n:N:l:p:g:E:w:B:C", opts,
                             &opt_index);
         if (c < 0)
             break;
@@ -296,6 +302,9 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
             break;
         case 'c':
             hfuzz->externalCommand = optarg;
+            break;
+        case 'C':
+            hfuzz->useSanCov = true;
             break;
         case 'F':
             hfuzz->maxFileSz = strtoul(optarg, NULL, 0);
@@ -402,11 +411,16 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         return false;
     }
 
+    if (hfuzz->dynFileMethod != _HF_DYNFILE_NONE && hfuzz->useSanCov) {
+        LOG_E("You cannot enable sanitizer coverage & perf feedback at the same time");
+        return false;
+    }
+
     if (strchr(hfuzz->fileExtn, '/')) {
         LOG_E("The file extension contains the '/' character: '%s'", hfuzz->fileExtn);
         return false;
     }
-    
+
     if (hfuzz->workDir[0] != '.') {
         if (!files_exists(hfuzz->workDir)) {
             LOG_E("Provided workspace directory '%s' doesn't exist", hfuzz->workDir);

--- a/cmdline.c
+++ b/cmdline.c
@@ -416,8 +416,8 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         return false;
     }
 
-    /* Adjust timeout due to sancov perf overhead */
-    if (hfuzz->useSanCov && hfuzz->tmOut < 20) {
+    /* Sanity checks for timeout. Optimal ranges highly depend on target */
+    if (hfuzz->useSanCov && hfuzz->tmOut < 15) {
         LOG_E("Timeout value (%ld) too small for sanitizer coverage feedback", hfuzz->tmOut);
         return false;
     }

--- a/cmdline.c
+++ b/cmdline.c
@@ -416,6 +416,12 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         return false;
     }
 
+    /* Adjust timeout due to sancov perf overhead */
+    if (hfuzz->useSanCov && hfuzz->tmOut < 20) {
+        LOG_E("Timeout value (%ld) too small for sanitizer coverage feedback", hfuzz->tmOut);
+        return false;
+    }
+
     if (strchr(hfuzz->fileExtn, '/')) {
         LOG_E("The file extension contains the '/' character: '%s'", hfuzz->fileExtn);
         return false;

--- a/common.h
+++ b/common.h
@@ -58,7 +58,10 @@
 #define _HF_VERIFIER_ITER   5
 
 /* Constant prefix used for single frame crashes stackhash masking */
-#define __HF_SINGLE_FRAME_MASK  0xBADBAD0000000000
+#define _HF_SINGLE_FRAME_MASK  0xBADBAD0000000000
+
+/* Size (in bytes) for report data to be stored in stack before written to file */
+#define _HF_REPORT_SIZE 8192
 
 typedef enum {
     _HF_DYNFILE_NONE = 0x0,
@@ -138,7 +141,7 @@ typedef struct fuzzer_t {
     uint64_t backtrace;
     uint64_t access;
     int exception;
-    char report[8192];
+    char report[_HF_REPORT_SIZE];
     bool mainWorker;
 
     /* For linux/ code */

--- a/common.h
+++ b/common.h
@@ -63,6 +63,14 @@
 /* Size (in bytes) for report data to be stored in stack before written to file */
 #define _HF_REPORT_SIZE 8192
 
+/* 
+ * Maximum number of iterations to keep same base seed file for dynamic preparation.
+ * Maintained iterations counters is set to zero if unique crash is detected or
+ * zero-set two MSB using following mask if crash is detected (might not be unique).
+ */
+#define _HF_MAX_DYNFILE_ITER 0x2000UL
+#define _HF_DYNFILE_SUB_MASK 0xFFFUL    // Zero-set two MSB
+
 typedef enum {
     _HF_DYNFILE_NONE = 0x0,
     _HF_DYNFILE_INSTR_COUNT = 0x1,
@@ -135,6 +143,7 @@ typedef struct {
     bool msanReportUMRS;
     void *ignoreAddr;
     bool useSanCov;
+    size_t dynFileIterExpire;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {

--- a/common.h
+++ b/common.h
@@ -81,6 +81,10 @@ typedef struct {
 } hwcnt_t;
 
 typedef struct {
+    uint64_t pcCnt;
+} sancovcnt_t;
+
+typedef struct {
     char **cmdline;
     char *inputFile;
     bool nullifyStdio;
@@ -124,11 +128,13 @@ typedef struct {
     size_t dynamicFileBestSz;
     dynFileMethod_t dynFileMethod;
     hwcnt_t hwCnts;
+    sancovcnt_t sanCovCnts;
     uint64_t dynamicCutOffAddr;
     pthread_mutex_t dynamicFile_mutex;
     bool disableRandomization;
     bool msanReportUMRS;
     void *ignoreAddr;
+    bool useSanCov;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {
@@ -147,6 +153,7 @@ typedef struct fuzzer_t {
     /* For linux/ code */
     uint8_t *dynamicFile;
     hwcnt_t hwCnts;
+    sancovcnt_t sanCovCnts;
     size_t dynamicFileSz;
 } fuzzer_t;
 

--- a/display.c
+++ b/display.c
@@ -30,6 +30,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "log.h"
 #include "util.h"
@@ -115,24 +116,31 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
         display_put("Coverage (max):\n");
     }
     if (hfuzz->dynFileMethod & _HF_DYNFILE_INSTR_COUNT) {
-        display_put("  - cpu instructions:      " ESC_BOLD "%zu" ESC_RESET "\n",
+        display_put("  - cpu instructions:      " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.cpuInstrCnt, 0UL));
     }
     if (hfuzz->dynFileMethod & _HF_DYNFILE_BRANCH_COUNT) {
-        display_put("  - cpu branches:          " ESC_BOLD "%zu" ESC_RESET "\n",
+        display_put("  - cpu branches:          " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.cpuBranchCnt, 0UL));
     }
     if (hfuzz->dynFileMethod & _HF_DYNFILE_UNIQUE_BLOCK_COUNT) {
-        display_put("  - unique branch targets: " ESC_BOLD "%zu" ESC_RESET "\n",
+        display_put("  - unique branch targets: " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.pcCnt, 0UL));
     }
     if (hfuzz->dynFileMethod & _HF_DYNFILE_UNIQUE_EDGE_COUNT) {
-        display_put("  - unique branch pairs:   " ESC_BOLD "%zu" ESC_RESET "\n",
+        display_put("  - unique branch pairs:   " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.pathCnt, 0UL));
     }
     if (hfuzz->dynFileMethod & _HF_DYNFILE_CUSTOM) {
-        display_put("  - custom counter:        " ESC_BOLD "%zu" ESC_RESET "\n",
+        display_put("  - custom counter:        " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.customCnt, 0UL));
+    }
+    if (hfuzz->useSanCov) {
+        display_put("Dynamic file size: " ESC_BOLD "%zu" ESC_RESET " (max: " ESC_BOLD "%zu"
+                    ESC_RESET ")\n", hfuzz->dynamicFileBestSz, hfuzz->maxFileSz);
+        display_put("Coverage (max):\n");
+        display_put("  - unique pc: " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
+                    __sync_fetch_and_add(&hfuzz->sanCovCnts.pcCnt, 0UL));
     }
     display_put("============================== LOGS ==============================\n");
 }

--- a/display.c
+++ b/display.c
@@ -41,7 +41,7 @@
 
 static void display_put(const char *fmt, ...)
 {
-    char buf[1024 * 512];
+    char buf[1024 * 4];
 
     va_list args;
     va_start(args, fmt);

--- a/display.c
+++ b/display.c
@@ -110,11 +110,17 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
     display_put("Timeouts: " ESC_BOLD "%zu" ESC_RESET "\n",
                 __sync_fetch_and_add(&hfuzz->timeoutedCnt, 0UL));
 
-    if (hfuzz->dynFileMethod != _HF_DYNFILE_NONE) {
+    /* Feedback data sources are enabled. Start with common headers. */
+    if (hfuzz->dynFileMethod != _HF_DYNFILE_NONE || hfuzz->useSanCov) {
         display_put("Dynamic file size: " ESC_BOLD "%zu" ESC_RESET " (max: " ESC_BOLD "%zu"
                     ESC_RESET ")\n", hfuzz->dynamicFileBestSz, hfuzz->maxFileSz);
+        display_put("Dynamic file max iterations keep for chosen seed (" ESC_BOLD "%zu" ESC_RESET
+                    "/" ESC_BOLD "%zu" ESC_RESET ")\n",
+                    __sync_fetch_and_add(&hfuzz->dynFileIterExpire, 0UL), _HF_MAX_DYNFILE_ITER);
         display_put("Coverage (max):\n");
     }
+
+    /* HW perf specific counters */
     if (hfuzz->dynFileMethod & _HF_DYNFILE_INSTR_COUNT) {
         display_put("  - cpu instructions:      " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.cpuInstrCnt, 0UL));
@@ -135,11 +141,10 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
         display_put("  - custom counter:        " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->hwCnts.customCnt, 0UL));
     }
+
+    /* Sanitizer coverage specific counters */
     if (hfuzz->useSanCov) {
-        display_put("Dynamic file size: " ESC_BOLD "%zu" ESC_RESET " (max: " ESC_BOLD "%zu"
-                    ESC_RESET ")\n", hfuzz->dynamicFileBestSz, hfuzz->maxFileSz);
-        display_put("Coverage (max):\n");
-        display_put("  - unique pc: " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
+        display_put("  - total #pc: " ESC_BOLD "%" PRIu64 ESC_RESET "\n",
                     __sync_fetch_and_add(&hfuzz->sanCovCnts.pcCnt, 0UL));
     }
     display_put("============================== LOGS ==============================\n");

--- a/fuzz.c
+++ b/fuzz.c
@@ -379,6 +379,9 @@ static void fuzz_perfFeedback(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         hfuzz->hwCnts.pathCnt = fuzzer->hwCnts.pathCnt;
         hfuzz->hwCnts.customCnt = fuzzer->hwCnts.customCnt;
 
+        /* Reset counter if better coverage achieved */
+        __sync_fetch_and_and(&hfuzz->dynFileIterExpire, 0UL);
+
         char currentBest[PATH_MAX], currentBestTmp[PATH_MAX];
         snprintf(currentBest, PATH_MAX, "%s/CURRENT_BEST", hfuzz->workDir);
         snprintf(currentBestTmp, PATH_MAX, "%s/.tmp.CURRENT_BEST", hfuzz->workDir);
@@ -412,6 +415,9 @@ static void fuzz_sanCovFeedback(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
         hfuzz->dynamicFileBestSz = fuzzer->dynamicFileSz;
         hfuzz->sanCovCnts.pcCnt = fuzzer->sanCovCnts.pcCnt;
+
+        /* Reset counter if better coverage achieved */
+        __sync_fetch_and_and(&hfuzz->dynFileIterExpire, 0UL);
 
         char currentBest[PATH_MAX], currentBestTmp[PATH_MAX];
         snprintf(currentBest, PATH_MAX, "%s/CURRENT_BEST", hfuzz->workDir);

--- a/fuzz.c
+++ b/fuzz.c
@@ -57,31 +57,11 @@ static int fuzz_sigReceived = 0;
 
 static pthread_t fuzz_mainThread;
 
-static inline UNUSED bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
-{
-    if (hfuzz->hwCnts.cpuInstrCnt == 0ULL && hfuzz->hwCnts.cpuBranchCnt == 0ULL
-        && hfuzz->hwCnts.pcCnt == 0ULL && hfuzz->hwCnts.pathCnt == 0ULL
-        && hfuzz->hwCnts.customCnt == 0ULL) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
 static inline UNUSED bool fuzz_isPerfCntsSet(honggfuzz_t * hfuzz)
 {
     if (hfuzz->hwCnts.cpuInstrCnt > 0ULL || hfuzz->hwCnts.cpuBranchCnt > 0ULL
         || hfuzz->hwCnts.pcCnt > 0ULL || hfuzz->hwCnts.pathCnt > 0ULL
         || hfuzz->hwCnts.customCnt > 0ULL) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-static inline bool fuzz_isSanCovCntsZero(honggfuzz_t * hfuzz)
-{
-    if (hfuzz->sanCovCnts.pcCnt == 0ULL) {
         return true;
     } else {
         return false;
@@ -155,7 +135,7 @@ static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, 
         goto skipMangling;
     }
     /* The first pass should be on an empty/initial file */
-    if (fuzz_isSanCovCntsZero(hfuzz) || fuzz_isSanCovCntsSet(hfuzz)) {
+    if (fuzz_isPerfCntsSet(hfuzz) || fuzz_isSanCovCntsSet(hfuzz)) {
         mangle_Resize(hfuzz, fuzzer->dynamicFile, &fuzzer->dynamicFileSz);
         mangle_mangleContent(hfuzz, fuzzer->dynamicFile, fuzzer->dynamicFileSz);
     }

--- a/fuzz.c
+++ b/fuzz.c
@@ -59,11 +59,10 @@ static pthread_t fuzz_mainThread;
 
 static inline bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
 {
-    if (hfuzz->hwCnts.cpuInstrCnt == 0ULL && 
-        hfuzz->hwCnts.cpuBranchCnt == 0ULL && 
-        hfuzz->hwCnts.pcCnt == 0ULL && 
-        hfuzz->hwCnts.pathCnt == 0ULL && 
-        hfuzz->hwCnts.customCnt == 0ULL) {
+    if (hfuzz->hwCnts.cpuInstrCnt == 0ULL &&
+        hfuzz->hwCnts.cpuBranchCnt == 0ULL &&
+        hfuzz->hwCnts.pcCnt == 0ULL &&
+        hfuzz->hwCnts.pathCnt == 0ULL && hfuzz->hwCnts.customCnt == 0ULL) {
         return true;
     } else {
         return false;
@@ -75,8 +74,7 @@ static inline bool fuzz_isPerfCntsSet(honggfuzz_t * hfuzz)
     if (hfuzz->hwCnts.cpuInstrCnt > 0ULL ||
         hfuzz->hwCnts.cpuBranchCnt > 0ULL ||
         hfuzz->hwCnts.pcCnt > 0ULL ||
-        hfuzz->hwCnts.pathCnt > 0ULL ||
-        hfuzz->hwCnts.customCnt > 0ULL) {
+        hfuzz->hwCnts.pathCnt > 0ULL || hfuzz->hwCnts.customCnt > 0ULL) {
         return true;
     } else {
         return false;

--- a/fuzz.c
+++ b/fuzz.c
@@ -59,10 +59,9 @@ static pthread_t fuzz_mainThread;
 
 static inline bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
 {
-    if (hfuzz->hwCnts.cpuInstrCnt == 0ULL &&
-        hfuzz->hwCnts.cpuBranchCnt == 0ULL &&
-        hfuzz->hwCnts.pcCnt == 0ULL &&
-        hfuzz->hwCnts.pathCnt == 0ULL && hfuzz->hwCnts.customCnt == 0ULL) {
+    if (hfuzz->hwCnts.cpuInstrCnt == 0ULL && hfuzz->hwCnts.cpuBranchCnt == 0ULL
+        && hfuzz->hwCnts.pcCnt == 0ULL && hfuzz->hwCnts.pathCnt == 0ULL
+        && hfuzz->hwCnts.customCnt == 0ULL) {
         return true;
     } else {
         return false;
@@ -71,10 +70,9 @@ static inline bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
 
 static inline bool fuzz_isPerfCntsSet(honggfuzz_t * hfuzz)
 {
-    if (hfuzz->hwCnts.cpuInstrCnt > 0ULL ||
-        hfuzz->hwCnts.cpuBranchCnt > 0ULL ||
-        hfuzz->hwCnts.pcCnt > 0ULL ||
-        hfuzz->hwCnts.pathCnt > 0ULL || hfuzz->hwCnts.customCnt > 0ULL) {
+    if (hfuzz->hwCnts.cpuInstrCnt > 0ULL || hfuzz->hwCnts.cpuBranchCnt > 0ULL
+        || hfuzz->hwCnts.pcCnt > 0ULL || hfuzz->hwCnts.pathCnt > 0ULL
+        || hfuzz->hwCnts.customCnt > 0ULL) {
         return true;
     } else {
         return false;

--- a/fuzz.c
+++ b/fuzz.c
@@ -116,7 +116,8 @@ static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, 
     }
     /* The first pass should be on an empty/initial file */
     if (hfuzz->hwCnts.cpuInstrCnt > 0 || hfuzz->hwCnts.cpuBranchCnt > 0 || hfuzz->hwCnts.pcCnt > 0
-        || hfuzz->hwCnts.pathCnt > 0 || hfuzz->hwCnts.customCnt > 0) {
+        || hfuzz->hwCnts.pathCnt > 0 || hfuzz->hwCnts.customCnt > 0
+        || hfuzz->sanCovCnts.pcCnt > 0) {
         mangle_Resize(hfuzz, fuzzer->dynamicFile, &fuzzer->dynamicFileSz);
         mangle_mangleContent(hfuzz, fuzzer->dynamicFile, fuzzer->dynamicFileSz);
     }
@@ -391,6 +392,7 @@ static void fuzz_sanCovFeedback(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
         memcpy(hfuzz->dynamicFileBest, fuzzer->dynamicFile, fuzzer->dynamicFileSz);
 
+        hfuzz->dynamicFileBestSz = fuzzer->dynamicFileSz;
         hfuzz->sanCovCnts.pcCnt = fuzzer->sanCovCnts.pcCnt;
 
         char currentBest[PATH_MAX], currentBestTmp[PATH_MAX];

--- a/fuzz.c
+++ b/fuzz.c
@@ -57,7 +57,8 @@ static int fuzz_sigReceived = 0;
 
 static pthread_t fuzz_mainThread;
 
-static inline bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
+static inline UNUSED
+bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
 {
     if (hfuzz->hwCnts.cpuInstrCnt == 0ULL && hfuzz->hwCnts.cpuBranchCnt == 0ULL
         && hfuzz->hwCnts.pcCnt == 0ULL && hfuzz->hwCnts.pathCnt == 0ULL
@@ -68,7 +69,8 @@ static inline bool fuzz_isPerfCntsZero(honggfuzz_t * hfuzz)
     }
 }
 
-static inline bool fuzz_isPerfCntsSet(honggfuzz_t * hfuzz)
+static inline UNUSED
+bool fuzz_isPerfCntsSet(honggfuzz_t * hfuzz)
 {
     if (hfuzz->hwCnts.cpuInstrCnt > 0ULL || hfuzz->hwCnts.cpuBranchCnt > 0ULL
         || hfuzz->hwCnts.pcCnt > 0ULL || hfuzz->hwCnts.pathCnt > 0ULL

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -74,7 +74,7 @@
 #if defined(__ANDROID__)
 #define kSAN_COV_OPTS  "coverage=1:coverage_direct=1"
 #else
-#define kSAN_COV_OPTS  "coverage=1"
+#define kSAN_COV_OPTS  "coverage=1:coverage_direct=1"
 #endif
 
 pid_t arch_fork(honggfuzz_t * hfuzz)

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -48,8 +48,30 @@
 
 #include "linux/perf.h"
 #include "linux/ptrace_utils.h"
+#include "linux/sancov.h"
 #include "log.h"
 #include "util.h"
+
+#define kASAN_OPTS      "allow_user_segv_handler=1:"\
+                        "handle_segv=0:"\
+                        "abort_on_error=1:"\
+                        "allocator_may_return_null=1"
+
+/* 'coverage_dir' output directory for coverage data files is set dynammically */
+#define kSANCOVDIR      "coverage_dir="
+
+/*
+ * If the program ends with a signal that ASan does not handle (or can not 
+ * handle at all, like SIGKILL), coverage data will be lost. This is a big
+ * problem on Android, where SIGKILL is a normal way of evicting applications 
+ * from memory. With 'coverage_direct=1' coverage data is written to a 
+ * memory-mapped file as soon as it collected. 
+ */
+#if defined(__ANDROID__)
+#define kASAN_COV_OPTS  kASAN_OPTS":coverage=1:coverage_direct=1"
+#else
+#define kASAN_COV_OPTS  kASAN_OPTS":coverage=1"
+#endif
 
 pid_t arch_fork(honggfuzz_t * hfuzz)
 {
@@ -85,10 +107,14 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
     /*
      * Tell asan to ignore SEGVs
      */
-    if (setenv
-        ("ASAN_OPTIONS",
-         "allow_user_segv_handler=1:handle_segv=0:abort_on_error=1:allocator_may_return_null=1",
-         1) == -1) {
+    const char *asan_options = kASAN_OPTS;
+    if (hfuzz->useSanCov) {
+        char sancov_opts[sizeof(kASAN_COV_OPTS) + 14 + PATH_MAX] = { 0 };
+        snprintf(sancov_opts, sizeof(sancov_opts), "%s:%s%s", kASAN_COV_OPTS, kSANCOVDIR,
+                 hfuzz->workDir);
+        asan_options = sancov_opts;
+    }
+    if (setenv("ASAN_OPTIONS", asan_options, 1) == -1) {
         PLOG_E("setenv(ASAN_OPTIONS) failed");
         return false;
     }
@@ -328,6 +354,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     }
     arch_removeTimer(&timerid);
     arch_perfAnalyze(hfuzz, fuzzer, &perfFds);
+    arch_sanCovAnalyze(hfuzz, fuzzer);
 }
 
 bool arch_archInit(honggfuzz_t * hfuzz)

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -856,6 +856,9 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     /* Increase global crashes counter */
     __sync_fetch_and_add(&hfuzz->crashesCnt, 1UL);
 
+    /* If crash detected, zero set two MSB */
+    __sync_fetch_and_and(&hfuzz->dynFileIterExpire, _HF_DYNFILE_SUB_MASK);
+
     /* 
      * Check if stackhash is blacklisted
      */
@@ -900,6 +903,9 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
         LOG_I("Ok, that's interesting, saved '%s' as '%s'", fuzzer->fileName,
               fuzzer->crashFileName);
         __sync_fetch_and_add(&hfuzz->uniqueCrashesCnt, 1UL);
+
+        /* If unique crash found, reset dynFile counter */
+        __sync_fetch_and_and(&hfuzz->dynFileIterExpire, 0UL);
     } else {
         if (dstFileExists) {
             LOG_I("It seems that '%s' already exists, skipping", fuzzer->crashFileName);

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -840,7 +840,7 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
      * If worker crashFileName member is set, it means that a tid has already crashed
      * from target master thread.
      */
-    if (fuzzer->crashFileName) {
+    if (fuzzer->crashFileName[0] != '\0') {
         LOG_D("Multiple crashes detected from worker against attached tids group");
 
         /*

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -664,7 +664,7 @@ static void arch_hashCallstack(fuzzer_t * fuzzer, funcs_t * funcs, size_t funcCn
      * not be enabled (e.g. fuzzer worker is from verifier).
      */
     if (enableMasking && funcCnt == 1) {
-        hash |= __HF_SINGLE_FRAME_MASK;
+        hash |= _HF_SINGLE_FRAME_MASK;
     }
     fuzzer->backtrace = hash;
 }

--- a/linux/sancov.c
+++ b/linux/sancov.c
@@ -49,7 +49,7 @@ void arch_sanCovAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     /* 
      * Firstly check case where target exited normally 
      * or with sanitizer handled signal. Otherwise proceed
-     * with rawunpack method
+     * with rawunpack method.
      */
     snprintf(covFile, sizeof(covFile), "%s.%d.sancov", files_basename(hfuzz->cmdline[0]),
              fuzzer->pid);
@@ -67,11 +67,9 @@ void arch_sanCovAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
         /* Check magic values & derive PC length */
         uint64_t magic = util_getUINT64(dataBuf);
-        LOG_E("Magic: %" PRIx64 "", magic);
         if (magic == kMagic32) {
-            LOG_D("32bit target");
+            is32bit = true;
         } else if (magic == kMagic64) {
-            LOG_D("64bit target");
             is32bit = false;
         } else {
             LOG_E("Invalid coverage data file");

--- a/linux/sancov.c
+++ b/linux/sancov.c
@@ -1,0 +1,116 @@
+/*
+ *
+ * honggfuzz - sanitizer coverage feedback parsing
+ * -----------------------------------------------
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+#include "common.h"
+#include "sancov.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <sys/mman.h>
+#include <inttypes.h>
+
+#include "util.h"
+#include "files.h"
+#include "log.h"
+
+/* Magic values */
+#define kMagic32 0xC0BFFFFFFFFFFF32
+#define kMagic64 0xC0BFFFFFFFFFFF64
+
+void arch_sanCovAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
+{
+    if (!hfuzz->useSanCov) {
+        return;
+    }
+
+    int dataFd = -1;
+    uint8_t *dataBuf = NULL;
+    off_t dataFileSz = 0, pos = 0;
+    bool is32bit = true;
+    char covFile[PATH_MAX] = { 0 };
+
+    /* 
+     * Firstly check case where target exited normally 
+     * or with sanitizer handled signal. Otherwise proceed
+     * with rawunpack method
+     */
+    snprintf(covFile, sizeof(covFile), "%s.%d.sancov", files_basename(hfuzz->cmdline[0]),
+             fuzzer->pid);
+    if (files_exists(covFile)) {
+        dataBuf = files_mapFile(covFile, &dataFileSz, &dataFd, false);
+        if (dataBuf == NULL) {
+            LOG_E("Couldn't open and map '%s' in R/O mode", covFile);
+            return;
+        }
+
+        if (dataFileSz < 8) {
+            LOG_E("Coverage data file too short");
+            goto bail;
+        }
+
+        /* Check magic values & derive PC length */
+        uint64_t magic = util_getUINT64(dataBuf);
+        LOG_E("Magic: %" PRIx64 "", magic);
+        if (magic == kMagic32) {
+            LOG_D("32bit target");
+        } else if (magic == kMagic64) {
+            LOG_D("64bit target");
+            is32bit = false;
+        } else {
+            LOG_E("Invalid coverage data file");
+            goto bail;
+        }
+        pos += 8;
+    }else {
+        /* TODO: Add PC length detection, for now assume 32bit only */
+        snprintf(covFile, sizeof(covFile), "%d.sancov.raw", fuzzer->pid);
+        
+        dataBuf = files_mapFile(covFile, &dataFileSz, &dataFd, false);
+        if (dataBuf == NULL) {
+            LOG_E("Couldn't open and map '%s' in R/O mode", covFile);
+            return;
+        }
+        /* TODO: Parse .map file and target only interesting PCs */
+    }
+
+    uint64_t nPCs = 0;
+    while (pos < dataFileSz) {
+        if (is32bit) {
+            uint32_t pc = util_getUINT32(dataBuf + pos);
+            pos += 4;
+            if (pc == 0x0) continue;
+        } else {
+            uint64_t pc = util_getUINT64(dataBuf + pos);
+            pos += 8;
+            if (pc == 0x0) continue;
+        }
+        nPCs++;
+    }
+    fuzzer->sanCovCnts.pcCnt = nPCs;    
+
+ bail:
+    unlink(covFile);
+    if (dataBuf) {
+        munmap(dataBuf, dataFileSz);
+    }
+    if (dataFd != -1) {
+        close(dataFd);
+    }
+}

--- a/linux/sancov.c
+++ b/linux/sancov.c
@@ -78,10 +78,12 @@ void arch_sanCovAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
             goto bail;
         }
         pos += 8;
-    }else {
+    } else {
         /* TODO: Add PC length detection, for now assume 32bit only */
+        snprintf(covFile, sizeof(covFile), "%d.sancov.map", fuzzer->pid);
+        unlink(covFile);
         snprintf(covFile, sizeof(covFile), "%d.sancov.raw", fuzzer->pid);
-        
+
         dataBuf = files_mapFile(covFile, &dataFileSz, &dataFd, false);
         if (dataBuf == NULL) {
             LOG_E("Couldn't open and map '%s' in R/O mode", covFile);
@@ -95,15 +97,17 @@ void arch_sanCovAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         if (is32bit) {
             uint32_t pc = util_getUINT32(dataBuf + pos);
             pos += 4;
-            if (pc == 0x0) continue;
+            if (pc == 0x0)
+                continue;
         } else {
             uint64_t pc = util_getUINT64(dataBuf + pos);
             pos += 8;
-            if (pc == 0x0) continue;
+            if (pc == 0x0)
+                continue;
         }
         nPCs++;
     }
-    fuzzer->sanCovCnts.pcCnt = nPCs;    
+    fuzzer->sanCovCnts.pcCnt = nPCs;
 
  bail:
     unlink(covFile);

--- a/linux/sancov.h
+++ b/linux/sancov.h
@@ -1,0 +1,25 @@
+/*
+ *
+ * honggfuzz - sanitizer coverage feedback parsing
+ * -----------------------------------------------
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+#ifndef _SANCOV_H_
+#define _SANCOV_H_
+
+extern void arch_sanCovAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer);
+
+#endif

--- a/util.c
+++ b/util.c
@@ -299,13 +299,13 @@ extern uint64_t util_getUINT64(const uint8_t * buf)
         b4 = buf[4], b5 = buf[5], b6 = buf[6], b7 = buf[7];
 
 #if __BYTE_ORDER == __BIG_ENDIAN
-    return ((uint64_t) b0 << 56) | ((uint64_t) b1 << 48) | ((uint64_t) b2 << 40) | ((uint64_t) b3 <<
-                                                                                    32) |
-        ((uint64_t) b4 << 24) | ((uint64_t) b5 << 16) | ((uint64_t) b6 << 8) | (uint64_t) b7;
+    return ((uint64_t) b0 << 56) | ((uint64_t) b1 << 48) | ((uint64_t) b2 << 40) |
+        ((uint64_t) b3 << 32) | ((uint64_t) b4 << 24) | ((uint64_t) b5 << 16) |
+        ((uint64_t) b6 << 8) | (uint64_t) b7;
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
-    return ((uint64_t) b7 << 56) | ((uint64_t) b6 << 48) | ((uint64_t) b5 << 40) | ((uint64_t) b4 <<
-                                                                                    32) |
-        ((uint64_t) b3 << 24) | ((uint64_t) b2 << 16) | ((uint64_t) b1 << 8) | (uint64_t) b0;
+    return ((uint64_t) b7 << 56) | ((uint64_t) b6 << 48) | ((uint64_t) b5 << 40) |
+        ((uint64_t) b4 << 32) | ((uint64_t) b3 << 24) | ((uint64_t) b2 << 16) |
+        ((uint64_t) b1 << 8) | (uint64_t) b0;
 #else
 #error "Unknown ENDIANNESS"
 #endif

--- a/util.c
+++ b/util.c
@@ -96,6 +96,12 @@ void util_rndBuf(uint8_t * buf, size_t sz)
     }
 }
 
+/* 
+ * Function has variable length stack size, although already we know it's invoked
+ * with relatively small sizes (max is _HF_REPORT_SIZE), thus safe to silent warning.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
 int util_vssnprintf(char *str, size_t size, const char *format, va_list ap)
 {
     char buf1[size];
@@ -122,6 +128,8 @@ int util_ssnprintf(char *str, size_t size, const char *format, ...)
 
     return snprintf(str, size, "%s%s", buf1, buf2);
 }
+
+#pragma GCC diagnostic pop      /* EOF diagnostic ignored "-Wstack-usage=" */
 
 void util_getLocalTime(const char *fmt, char *buf, size_t len, time_t tm)
 {
@@ -222,7 +230,7 @@ extern uint16_t util_ToFromBE16(uint16_t val)
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
     return SWAP16(val);
 #else
-#error "Unknown ENDIANESS"
+#error "Unknown ENDIANNESS"
 #endif
 }
 
@@ -233,7 +241,7 @@ extern uint16_t util_ToFromLE16(uint16_t val)
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
     return val;
 #else
-#error "Unknown ENDIANESS"
+#error "Unknown ENDIANNESS"
 #endif
 }
 
@@ -244,7 +252,7 @@ extern uint32_t util_ToFromBE32(uint32_t val)
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
     return SWAP32(val);
 #else
-#error "Unknown ENDIANESS"
+#error "Unknown ENDIANNESS"
 #endif
 }
 
@@ -255,7 +263,51 @@ extern uint32_t util_ToFromLE32(uint32_t val)
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
     return val;
 #else
-#error "Unknown ENDIANESS"
+#error "Unknown ENDIANNESS"
+#endif
+}
+
+extern uint16_t util_getUINT16(const uint8_t * buf)
+{
+    const uint8_t b0 = buf[0], b1 = buf[1];
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+    return (b0 << 8) | b1;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+    return (b1 << 8) | b0;
+#else
+#error "Unknown ENDIANNESS"
+#endif
+}
+
+extern uint32_t util_getUINT32(const uint8_t * buf)
+{
+    const uint8_t b0 = buf[0], b1 = buf[1], b2 = buf[2], b3 = buf[3];
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+    return ((uint32_t) b0 << 24) | ((uint32_t) b1 << 16) | ((uint32_t) b2 << 8) | (uint32_t) b3;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+    return ((uint32_t) b3 << 24) | ((uint32_t) b2 << 16) | ((uint32_t) b1 << 8) | (uint32_t) b0;
+#else
+#error "Unknown ENDIANNESS"
+#endif
+}
+
+extern uint64_t util_getUINT64(const uint8_t * buf)
+{
+    const uint8_t b0 = buf[0], b1 = buf[1], b2 = buf[2], b3 = buf[3],
+        b4 = buf[4], b5 = buf[5], b6 = buf[6], b7 = buf[7];
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+    return ((uint64_t) b0 << 56) | ((uint64_t) b1 << 48) | ((uint64_t) b2 << 40) | ((uint64_t) b3 <<
+                                                                                    32) |
+        ((uint64_t) b4 << 24) | ((uint64_t) b5 << 16) | ((uint64_t) b6 << 8) | (uint64_t) b7;
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+    return ((uint64_t) b7 << 56) | ((uint64_t) b6 << 48) | ((uint64_t) b5 << 40) | ((uint64_t) b4 <<
+                                                                                    32) |
+        ((uint64_t) b3 << 24) | ((uint64_t) b2 << 16) | ((uint64_t) b1 << 8) | (uint64_t) b0;
+#else
+#error "Unknown ENDIANNESS"
 #endif
 }
 

--- a/util.c
+++ b/util.c
@@ -101,7 +101,7 @@ void util_rndBuf(uint8_t * buf, size_t sz)
  * with relatively small sizes (max is _HF_REPORT_SIZE), thus safe to silent warning.
  */
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstack-usage="
+#pragma GCC diagnostic ignored "-Wframe-larger-than="
 int util_vssnprintf(char *str, size_t size, const char *format, va_list ap)
 {
     char buf1[size];

--- a/util.h
+++ b/util.h
@@ -51,6 +51,9 @@ extern uint16_t util_ToFromBE16(uint16_t val);
 extern uint16_t util_ToFromLE16(uint16_t val);
 extern uint32_t util_ToFromBE32(uint32_t val);
 extern uint32_t util_ToFromLE32(uint32_t val);
+extern uint16_t util_getUINT16(const uint8_t * buf);
+extern uint32_t util_getUINT32(const uint8_t * buf);
+extern uint64_t util_getUINT64(const uint8_t * buf);
 
 extern void MX_LOCK(pthread_mutex_t * mutex);
 extern void MX_UNLOCK(pthread_mutex_t * mutex);


### PR DESCRIPTION
## Overview
This PR introduces support for sanitizer coverage feedback by parsing sancov files generated from targets compiled with clang sanitizer (ASan, MSan, UBSan, etc.) coverage enabled. Feedback data parsing is very simple for now (only #PCs is parsed), although more advanced counters (such as BasicBlock) are on the todo list. Some additional feedback decision improvements have been introduced while working with sancov parsing.

Performance overhead for sancov enabled targets has been noticed roughly around 30-40% for some basic media file format decoders. Thus still have mixed thoughts as to what extend it's worth being used. While working with the evolutionary engine another thought that popped is to use feedback data to generate a set of test files with good coverage and then disable evolution for certain time-frames. Will do some more testing on that and follow-up if it's worth it. Feedback & request for improvements are welcome.

## Linux feedback improvements (expire dynamic file)
While working integrating sancov noticed that prepareFileDynamically is choosing an initial seed for the dynamic file and this file is never replaced. As such until campaign is stopped and restarted the same dynFile will be used. I think this is not desired for most cases since feedback evolution might hit a dead-end and thus trap in an exec loop that doesn't present any improvements or crashes. As an improvement effort in that area an additional iterations counter has been added to flag expired dynFiles. Counter is increased from main fuzzLoop and when hits  _HF_MAX_DYNFILE_ITER file is replaced with new seed. Counter is reset if unique crash is detected or better coverage is achieved. Additionally, counter has its two MSB zero-set when a non-unique crash is detected aiming for faster exist from already tested areas. Current max is 8192 and can be adjusted via common header.

## Sanitizer coverage support
sancov.c implements a basic PC enumeration from .sancov or .sancov.raw files. More feedback [data](http://clang.llvm.org/docs/SanitizerCoverage.html) parsing is on the todo list. New struct has been introduced to do the book-keeping of the counters following same pattern with HW perf.

Sanitizer flags are adjusted in Linux arch.c to export the appropriate flags required to enable sanitizer coverage data generation. sancov files are deleted after being parsed.

Sancov feedback can be enabled with "-C" flag. While sancov is developed it's prevented from being used in parallel with HW perf feedback. This can change in the future if sancov reaches a stable state.

## Generic improvements
* Some basic stack size monitor logic has been added to verify at compile time that stack sizes are maintained at accepted levels covering possible less resource-full targets such as old Android OS devices.
* Export ANDROID_NDK_TOOLCHAIN for cases were user wants to replace default Android NDK toolchain.
* Verify workDir directory exists before starting fuzzLoop
* Various typos and print format fixes
* Reduce size of display stack helper buffer