### PR TITLE
FEEDBACK: Reset global counters when new seed picked

### DIFF
--- a/files.c
+++ b/files.c
@@ -429,7 +429,7 @@ bool files_parseBlacklist(honggfuzz_t * hfuzz)
         }
 
         hfuzz->blacklist[hfuzz->blacklistCnt] = strtoull(lineptr, 0, 16);
-        LOG_D("Blacklist: loaded %'" PRId64 "'", hfuzz->blacklist[hfuzz->blacklistCnt]);
+        LOG_D("Blacklist: loaded %'" PRIu64 "'", hfuzz->blacklist[hfuzz->blacklistCnt]);
 
         // Verify entries are sorted so we can use interpolation search
         if (hfuzz->blacklistCnt > 1) {

--- a/fuzz.c
+++ b/fuzz.c
@@ -377,8 +377,8 @@ static void fuzz_perfFeedback(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     if (diff0 <= 0 && diff1 <= 0 && diff2 <= 0 && diff3 <= 0 && diff4 <= 0) {
 
         LOG_I("New: (Size New,Old): %zu,%zu, Perf (Cur,New): %"
-              PRId64 "/%" PRId64 "/%" PRId64 "/%" PRId64 "/%" PRId64 ",%" PRId64 "/%" PRId64
-              "/%" PRId64 "/%" PRId64 "/%" PRId64, fuzzer->dynamicFileSz,
+              PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 ",%" PRIu64 "/%" PRIu64
+              "/%" PRIu64 "/%" PRIu64 "/%" PRIu64, fuzzer->dynamicFileSz,
               hfuzz->dynamicFileBestSz, hfuzz->hwCnts.cpuInstrCnt, hfuzz->hwCnts.cpuBranchCnt,
               hfuzz->hwCnts.pcCnt, hfuzz->hwCnts.pathCnt, hfuzz->hwCnts.customCnt,
               fuzzer->hwCnts.cpuInstrCnt, fuzzer->hwCnts.cpuBranchCnt, fuzzer->hwCnts.pcCnt,
@@ -422,7 +422,7 @@ static void fuzz_sanCovFeedback(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
     if (diff0 < 0) {
         LOG_I("SanCov Update: file size (Cur,New): %zu,%zu, counters (Cur/New): %"
-              PRId64 "/%" PRId64, hfuzz->dynamicFileBestSz, fuzzer->dynamicFileSz,
+              PRIu64 "/%" PRIu64, hfuzz->dynamicFileBestSz, fuzzer->dynamicFileSz,
               hfuzz->sanCovCnts.pcCnt, fuzzer->sanCovCnts.pcCnt);
 
         memcpy(hfuzz->dynamicFileBest, fuzzer->dynamicFile, fuzzer->dynamicFileSz);

--- a/linux/perf.c
+++ b/linux/perf.c
@@ -405,7 +405,7 @@ void arch_perfAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, perfFd_t * perfFds
         pathCount = arch_perfCountBranches();
 
         if (perfRecordsLost > 0UL) {
-            LOG_W("%" PRId64
+            LOG_W("%" PRIu64
                   " PERF_RECORD_LOST events received, possibly too many concurrent fuzzing threads in progress",
                   perfRecordsLost);
         }
@@ -419,7 +419,7 @@ void arch_perfAnalyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, perfFd_t * perfFds
         edgeCount = arch_perfCountBranches();
 
         if (perfRecordsLost > 0UL) {
-            LOG_W("%" PRId64
+            LOG_W("%" PRIu64
                   " PERF_RECORD_LOST events received, possibly too many concurrent fuzzing threads in progress",
                   perfRecordsLost);
         }

--- a/mangle.c
+++ b/mangle.c
@@ -252,7 +252,7 @@ static void mangle_AddSub(honggfuzz_t * hfuzz UNUSED, uint8_t * buf, size_t bufS
         }
     default:
         {
-            LOG_F("Unknown variable length size: %" PRId64, varLen);
+            LOG_F("Unknown variable length size: %" PRIu64, varLen);
             break;
         }
     }

--- a/util.c
+++ b/util.c
@@ -58,7 +58,7 @@ static __thread uint64_t rndIni = false;
 uint64_t util_rndGet(uint64_t min, uint64_t max)
 {
     if (min > max) {
-        LOG_F("min:%" PRId64 " > max:%" PRId64, min, max);
+        LOG_F("min:%" PRIu64 " > max:%" PRIu64, min, max);
     }
 
     if (util_urandomFd == -1) {


### PR DESCRIPTION
Add a helper function to reset all feedback counters (HW PERF & SANCOV) when dynFile counter expired and new seed is picked up.
