### PR TITLE
LINUX: Make workers' lock status var global

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -217,6 +217,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
                     .ubsanOpts = NULL,
         },
         .numMajorFrames = 7,
+        .isDynFileLocked = false,
     };
     /*  *INDENT-ON* */
 

--- a/common.h
+++ b/common.h
@@ -207,6 +207,7 @@ typedef struct {
     pthread_mutex_t workersBlock_mutex;
     sanOpts_t sanOpts;
     size_t numMajorFrames;
+    bool isDynFileLocked;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {
@@ -227,7 +228,6 @@ typedef struct fuzzer_t {
     hwcnt_t hwCnts;
     sancovcnt_t sanCovCnts;
     size_t dynamicFileSz;
-    bool isDynFileLocked;
 } fuzzer_t;
 
 #define _HF_MAX_FUNCS 80


### PR DESCRIPTION
Having isDynFileLocked variable as member of fuzzer_t struct was creating races between checkpoints
blocking some workers permanently. Variable has been moved to honggfuzz_t global struct to avoid blocking workers of various type (main, verifier, etc.) when operating in parallel.