### PR TITLE
LINUX: Deal gracefully with ASan nested crashes

### DIFF
--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -1112,6 +1112,11 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
 
     /* If ASan crash, parse report */
     if (exitCode == HF_ASAN_EXIT_CODE) {
+
+        /* ASan is saving reports against parent PID */
+        if (fuzzer->pid != pid) {
+            return;
+        }
         funcCnt = arch_parseAsanReport(hfuzz, pid, funcs, &crashAddr, &op);
 
         /*
@@ -1257,8 +1262,7 @@ static void arch_ptraceExitAnalyzeData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t 
     arch_hashCallstack(hfuzz, fuzzer, funcs, funcCnt, false);
 }
 
-static inline void arch_ptraceExitAnalyze(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzzer,
-                                          int exitCode)
+void arch_ptraceExitAnalyze(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzzer, int exitCode)
 {
     if (fuzzer->mainWorker) {
         /* Main fuzzing threads */

--- a/linux/ptrace_utils.h
+++ b/linux/ptrace_utils.h
@@ -42,6 +42,7 @@
 extern bool arch_ptraceWaitForPidStop(pid_t pid);
 extern bool arch_ptraceEnable(honggfuzz_t * hfuzz);
 extern void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * fuzzer);
+extern void arch_ptraceExitAnalyze(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzzer, int exitCode);
 extern bool arch_ptraceAttach(pid_t pid);
 extern void arch_ptraceDetach(pid_t pid);
 extern void arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid, uint64_t * cnt);


### PR DESCRIPTION
While fuzzing ASan instrumented targets in Android it has been noticed that sometimes ASan is crashing internally, while generating reports for detected error (nested crashes). Mostly null deref bugs or read addresses close to 0x0. In case ASan internal error does not raise a SIGSEGV the identified crash is lost since the AsanDie() procedure is never invoked from compiler-rt DSO.

If "abort_on_error" ASan flag is enabled (SIGABRT is monitored for target application) there is nothing that can be done if nested crash doesn't result to a SIGSEGV being raised. On the other hand if SIGABRT is not monitored and ASan reports are written in FS, an additional check is added
at the end of the worker actions to identify orphan reports that match PIDs that have not exited with expected exitcode. If such type of ASan reports are identified an attempt is made to parse their info and save the current mutated seed using info from corrupted report file.

This commit also effectively mitigates garbage ASan logs left behind in fuzzing workspace if compiler-rt procs crashes while processing identified errors at instrumented target.