### PR TITLE
LINUX: Typo in macro wrap breaking 32bit compilation

### DIFF
--- a/linux/perf.c
+++ b/linux/perf.c
@@ -80,7 +80,7 @@ static uint32_t perfIntelPtConfigShift = 0;
 #if __BITS_PER_LONG == 64
 const size_t perfBloomSz = (1024ULL * 1024ULL * 1024ULL);
 #elif __BITS_PER_LONG == 32
-const size_t perfBloomSz = (1024ULL * 1024ULL * 128ULL)
+const size_t perfBloomSz = (1024ULL * 1024ULL * 128ULL);
 #else
 #error "__BITS_PER_LONG not defined"
 #endif


### PR DESCRIPTION
Awesome work with Intel's PT. Will try to give it a spin against some real targets the next few days.