### PR TITLE
LINUX: Remote pid enhancements

### DIFF
--- a/common.h
+++ b/common.h
@@ -186,7 +186,6 @@ typedef struct {
     char **files;
     size_t fileCnt;
     size_t lastCheckedFileIndex;
-    pid_t pid;
     char *envs[128];
 
     time_t timeStart;
@@ -197,7 +196,7 @@ typedef struct {
     size_t blCrashesCnt;
     size_t timeoutedCnt;
 
-    /* For the linux/ code */
+    /* For the Linux code */
     uint8_t *dynamicFileBest;
     size_t dynamicFileBestSz;
     dynFileMethod_t dynFileMethod;
@@ -217,6 +216,8 @@ typedef struct {
     sanOpts_t sanOpts;
     size_t numMajorFrames;
     bool isDynFileLocked;
+    pid_t pid;
+    const char *pidFile;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {
@@ -232,7 +233,7 @@ typedef struct fuzzer_t {
     char report[_HF_REPORT_SIZE];
     bool mainWorker;
 
-    /* For linux/ code */
+    /* For Linux code */
     uint8_t *dynamicFile;
     hwcnt_t hwCnts;
     sancovcnt_t sanCovCnts;

--- a/files.c
+++ b/files.c
@@ -109,10 +109,7 @@ size_t files_readFromFd(int fd, uint8_t * buf, size_t fileSz)
         if (sz < 0 && errno == EINTR)
             continue;
 
-        if (sz < 0)
-            break;
-
-        if (sz == 0)
+        if (sz <= 0)
             break;
 
         readSz += sz;

--- a/files.c
+++ b/files.c
@@ -481,3 +481,36 @@ uint8_t *files_mapFile(char *fileName, off_t * fileSz, int *fd, bool isWritable)
     *fileSz = st.st_size;
     return buf;
 }
+
+bool files_readPidFromFile(const char *fileName, pid_t * pidPtr)
+{
+    bool ret = false;
+
+    FILE *fPID = fopen(fileName, "rb");
+    if (fPID == NULL) {
+        PLOG_E("Couldn't open '%s' - R/O mode", fileName);
+        return false;
+    }
+
+    char *lineptr = NULL;
+    size_t lineSz = 0;
+    if (getline(&lineptr, &lineSz, fPID) == -1) {
+        if (lineSz == 0) {
+            LOG_E("Empty PID file (%s)", fileName);
+            fclose(fPID);
+            goto bail;
+        }
+    }
+
+    *pidPtr = atoi(lineptr);
+    if (*pidPtr < 1) {
+        LOG_E("Invalid PID read from '%s' file", fileName);
+        goto bail;
+    }
+    ret = true;
+
+ bail:
+    free(lineptr);
+    fclose(fPID);
+    return ret;
+}

--- a/files.h
+++ b/files.h
@@ -53,4 +53,6 @@ extern bool files_parseBlacklist(honggfuzz_t * hfuzz);
 
 extern uint8_t *files_mapFile(char *fileName, off_t * fileSz, int *fd, bool isWritable);
 
+extern bool files_readPidFromFile(const char *fileName, pid_t * pidPtr);
+
 #endif

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -456,10 +456,10 @@ bool arch_archInit(honggfuzz_t * hfuzz)
             LOG_E("Kernel version '%s' not supporting chosen perf method", uts.release);
             return false;
         }
-    }
 
-    if (arch_perfInit(hfuzz) == false) {
-        return false;
+        if (arch_perfInit(hfuzz) == false) {
+            return false;
+        }
     }
 #if defined(__ANDROID__) && defined(__arm__)
     /*

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -1077,6 +1077,7 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
     REG_TYPE pc = 0;
     void *crashAddr = 0;
     char *op = "UNKNOWN";
+    pid_t targetPid = (hfuzz->pid > 0) ? hfuzz->pid : fuzzer->pid;
 
     /* Save only the first hit for each worker */
     if (fuzzer->crashFileName[0] != '\0') {
@@ -1114,7 +1115,7 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
     if (exitCode == HF_ASAN_EXIT_CODE) {
 
         /* ASan is saving reports against parent PID */
-        if (fuzzer->pid != pid) {
+        if (targetPid != pid) {
             return;
         }
         funcCnt = arch_parseAsanReport(hfuzz, pid, funcs, &crashAddr, &op);

--- a/util.c
+++ b/util.c
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include <ctype.h>
 
 #include "common.h"
 #include "files.h"
@@ -337,4 +338,17 @@ int64_t fastArray64Search(uint64_t * array, size_t arraySz, uint64_t key)
     } else {
         return -1;
     }
+}
+
+bool util_isANumber(const char *s)
+{
+    if (!isdigit(s[0])) {
+        return false;
+    }
+    for (int i = 0; s[i]; s++) {
+        if (!isdigit(s[i]) && s[i] != 'x') {
+            return false;
+        }
+    }
+    return true;
 }

--- a/util.c
+++ b/util.c
@@ -200,7 +200,7 @@ void util_recoverStdio(void)
 /*
  * This is not a cryptographically secure hash
  */
-extern uint64_t util_hash(const char *buf, size_t len)
+uint64_t util_hash(const char *buf, size_t len)
 {
     uint64_t ret = 0;
 
@@ -213,7 +213,7 @@ extern uint64_t util_hash(const char *buf, size_t len)
     return ret;
 }
 
-extern int64_t util_timeNowMillis(void)
+int64_t util_timeNowMillis(void)
 {
     struct timeval tv;
     if (gettimeofday(&tv, NULL) == -1) {
@@ -223,7 +223,7 @@ extern int64_t util_timeNowMillis(void)
     return (((int64_t) tv.tv_sec * 1000LL) + ((int64_t) tv.tv_usec / 1000LL));
 }
 
-extern uint16_t util_ToFromBE16(uint16_t val)
+uint16_t util_ToFromBE16(uint16_t val)
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return val;
@@ -234,7 +234,7 @@ extern uint16_t util_ToFromBE16(uint16_t val)
 #endif
 }
 
-extern uint16_t util_ToFromLE16(uint16_t val)
+uint16_t util_ToFromLE16(uint16_t val)
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return SWAP16(val);
@@ -245,7 +245,7 @@ extern uint16_t util_ToFromLE16(uint16_t val)
 #endif
 }
 
-extern uint32_t util_ToFromBE32(uint32_t val)
+uint32_t util_ToFromBE32(uint32_t val)
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return val;
@@ -256,7 +256,7 @@ extern uint32_t util_ToFromBE32(uint32_t val)
 #endif
 }
 
-extern uint32_t util_ToFromLE32(uint32_t val)
+uint32_t util_ToFromLE32(uint32_t val)
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return SWAP32(val);
@@ -267,7 +267,7 @@ extern uint32_t util_ToFromLE32(uint32_t val)
 #endif
 }
 
-extern uint64_t util_getUINT32(const uint8_t * buf)
+uint64_t util_getUINT32(const uint8_t * buf)
 {
     const uint8_t b0 = buf[0], b1 = buf[1], b2 = buf[2], b3 = buf[3];
 
@@ -282,7 +282,7 @@ extern uint64_t util_getUINT32(const uint8_t * buf)
 #endif
 }
 
-extern uint64_t util_getUINT64(const uint8_t * buf)
+uint64_t util_getUINT64(const uint8_t * buf)
 {
     const uint8_t b0 = buf[0], b1 = buf[1], b2 = buf[2], b3 = buf[3],
         b4 = buf[4], b5 = buf[5], b6 = buf[6], b7 = buf[7];
@@ -300,21 +300,21 @@ extern uint64_t util_getUINT64(const uint8_t * buf)
 #endif
 }
 
-extern void MX_LOCK(pthread_mutex_t * mutex)
+void MX_LOCK(pthread_mutex_t * mutex)
 {
     if (pthread_mutex_lock(mutex)) {
         PLOG_F("pthread_mutex_lock(%p)", mutex);
     }
 }
 
-extern void MX_UNLOCK(pthread_mutex_t * mutex)
+void MX_UNLOCK(pthread_mutex_t * mutex)
 {
     if (pthread_mutex_unlock(mutex)) {
         PLOG_F("pthread_mutex_unlock(%p)", mutex);
     }
 }
 
-extern int64_t fastArray64Search(uint64_t * array, size_t arraySz, uint64_t key)
+int64_t fastArray64Search(uint64_t * array, size_t arraySz, uint64_t key)
 {
     size_t low = 0;
     size_t high = arraySz - 1;

--- a/util.h
+++ b/util.h
@@ -59,4 +59,6 @@ extern void MX_UNLOCK(pthread_mutex_t * mutex);
 
 extern int64_t fastArray64Search(uint64_t * array, size_t arraySz, uint64_t key);
 
+extern bool util_isANumber(const char *s);
+
 #endif


### PR DESCRIPTION
* Enable remote pid fuzzing with sancov feedback. So far data were collected only against spawned fuzzers. If user spawns remote process with sanitizer flags matching honggfuzz's workspace directory naming conventions (<workDir>/HF_SANCOV, etc.), data can be collected against remote pid too.
* Add read pid from file option to benefit from auto-restart daemonized targets so that campaign can continue even if target crashed (read new pid from file).