### PR TITLE
ANDROID: Resolve IPT compilation issue

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -107,7 +107,7 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   LOCAL_C_INCLUDES := third_party/android/libunwind/include third_party/android/capstone/include
   LOCAL_STATIC_LIBRARIES := libunwind-arch libunwind libunwind-ptrace libunwind-dwarf-generic libcapstone
   LOCAL_CFLAGS += -D__HF_USE_CAPSTONE__
-  ARCH_SRCS := linux/arch.c linux/ptrace_utils.c linux/perf.c linux/unwind.c linux/sancov.c
+  ARCH_SRCS := linux/arch.c linux/ptrace_utils.c linux/perf.c linux/unwind.c linux/sancov.c linux/pt.c
   ARCH := LINUX
   ifeq ($(ARCH_ABI),arm)
     LOCAL_CFLAGS += -DOPENSSL_ARMCAP_ABI='$(OPENSSL_ARMCAP_ABI)'


### PR DESCRIPTION
Build 'pt.c' component to resolve undefined references
to 'arch_ptAnalyze()' from 'arch_perfMmapParse()'. IPT
has no value yet for Android x86/x64_86 ABIs due to
very old kernels. Add component instead of a disabling
macro for future benefit when new kernels adopted.