### PR TITLE
LINUX: Moar remote pid enhancements

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -204,6 +204,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         .numMajorFrames = 7,
         .isDynFileLocked = false,
         .pidFile = NULL,
+        .pidCmd = NULL,
     };
     /*  *INDENT-ON* */
 

--- a/common.h
+++ b/common.h
@@ -87,6 +87,9 @@
 #define _HF_MONITOR_SIGABRT 1
 #endif
 
+/* Size of remote pid cmdline char buffer */
+#define _HF_PROC_CMDLINE_SZ 8192
+
 typedef enum {
     _HF_DYNFILE_NONE = 0x0,
     _HF_DYNFILE_INSTR_COUNT = 0x1,
@@ -217,6 +220,7 @@ typedef struct {
     bool isDynFileLocked;
     pid_t pid;
     const char *pidFile;
+    char *pidCmd;
 } honggfuzz_t;
 
 typedef struct fuzzer_t {

--- a/display.c
+++ b/display.c
@@ -91,6 +91,10 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
 
     display_put("Input file/dir: '" ESC_BOLD "%s" ESC_RESET "'\n", hfuzz->inputFile);
     display_put("Fuzzed cmd: '" ESC_BOLD "%s" ESC_RESET "'\n", hfuzz->cmdline_txt);
+    if (hfuzz->pid > 0) {
+        display_put("Remote cmd [" ESC_BOLD "%d" ESC_RESET "]: '" ESC_BOLD "%s" ESC_RESET "'\n",
+                    hfuzz->pid, hfuzz->pidCmd);
+    }
 
     display_put("Fuzzing threads: " ESC_BOLD "%zu" ESC_RESET "\n", hfuzz->threadsMax);
     display_put("Execs per second: " ESC_BOLD "%zu" ESC_RESET " (avg: " ESC_BOLD "%zu" ESC_RESET

--- a/fuzz.c
+++ b/fuzz.c
@@ -749,6 +749,9 @@ void fuzz_main(honggfuzz_t * hfuzz)
     if (hfuzz->sanOpts.msanOpts) {
         free(hfuzz->sanOpts.msanOpts);
     }
+    if (hfuzz->pidCmd) {
+        free(hfuzz->pidCmd);
+    }
 
     _exit(EXIT_SUCCESS);
 }

--- a/report.c
+++ b/report.c
@@ -102,6 +102,7 @@ void report_Report(honggfuzz_t * hfuzz, char *s)
             " ignoreAddr   : %p\n"
             " memoryLimit  : %" PRIu64 " (MiB)\n"
             " targetPid    : %d\n"
+            " targetCmd    : %s\n"
             " wordlistFile : %s\n",
             localtmstr,
             hfuzz->flipRate,
@@ -110,7 +111,8 @@ void report_Report(honggfuzz_t * hfuzz, char *s)
             hfuzz->tmOut,
             hfuzz->ignoreAddr,
             hfuzz->asLimit,
-            hfuzz->pid, hfuzz->dictionaryFile == NULL ? "NULL" : hfuzz->dictionaryFile);
+            hfuzz->pid, hfuzz->pidCmd,
+            hfuzz->dictionaryFile == NULL ? "NULL" : hfuzz->dictionaryFile);
 
 #if defined(_HF_ARCH_LINUX)
     report_printdynFileMethod(hfuzz);


### PR DESCRIPTION
### Fix remote pid re-attach bug
When pid from file flag used and remote pid has been updated (new pid read from file), static boolean flag will never change preventing reapChild from attaching to new pid. Slightly modify the logic to attach again to long-lived process when new pid detected.

### Use procfs to resolve remote pid cmd
Use remote pid cmdline string for display screen and reports