### PR TITLE
Link to USAGE.md instead of itself (README.md).

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Description**
 
-  * A general-purpose, easy-to-use fuzzer with interesting analysis options. See [README](https://github.com/google/honggfuzz/blob/master/README.md) wiki page for more details
+  * A general-purpose, easy-to-use fuzzer with interesting analysis options. See [USAGE](https://github.com/google/honggfuzz/blob/master/docs/USAGE.md) for more details
   * Supports hardware-based [feedback-driven fuzzing](https://github.com/google/honggfuzz/blob/master/docs/FeedbackDrivenFuzzing.md) (requires Linux and a supported CPU model), also for closed-source binaries
   * It works, at least, under GNU/Linux, FreeBSD, Mac OSX and [Android](https://github.com/google/honggfuzz/blob/master/docs/Android.md)
   * [Can fuzz long-lasting processes](https://github.com/google/honggfuzz/blob/master/docs/AttachingToPid.md) (e.g. network servers like Apache's httpd and ISC's bind)


### PR DESCRIPTION
USAGE.md contains the features and usage details, and README.md does not.

Reference: #57.