### PR TITLE
[MAC] Add original filename to the crash.

### DIFF
--- a/mac/arch.c
+++ b/mac/arch.c
@@ -220,19 +220,21 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
                  hfuzz->workDir, fuzzer->origFileName);
     } else if (hfuzz->saveUnique) {
         snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
-                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s",
+                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s.%s",
                  hfuzz->workDir, arch_sigs[termsig].descr,
                  exception_to_string(fuzzer->exception), fuzzer->pc,
-                 fuzzer->backtrace, fuzzer->access, hfuzz->fileExtn);
+                 fuzzer->backtrace, fuzzer->access, fuzzer->origFileName,
+                 hfuzz->fileExtn);
     } else {
         char localtmstr[PATH_MAX];
         util_getLocalTime("%F.%H.%M.%S", localtmstr, sizeof(localtmstr), time(NULL));
 
         snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
-                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.TIME.%s.PID.%.5d.%s",
+                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.TIME.%s.PID.%.5d.%s.%s",
                  hfuzz->workDir, arch_sigs[termsig].descr,
                  exception_to_string(fuzzer->exception), fuzzer->pc,
-                 fuzzer->backtrace, fuzzer->access, localtmstr, fuzzer->pid, hfuzz->fileExtn);
+                 fuzzer->backtrace, fuzzer->access, localtmstr, fuzzer->pid,
+                 fuzzer->origFileName, hfuzz->fileExtn);
     }
 
     if (files_exists(fuzzer->crashFileName)) {


### PR DESCRIPTION
It is useful for minimization to be able to get
the original filename given a crash sample.