### PR TITLE
[MAC] Add HF report file support

### DIFF
--- a/mac/arch.c
+++ b/mac/arch.c
@@ -240,21 +240,19 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
                  hfuzz->workDir, fuzzer->origFileName);
     } else if (hfuzz->saveUnique) {
         snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
-                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s.%s",
+                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.%s",
                  hfuzz->workDir, arch_sigs[termsig].descr,
                  exception_to_string(fuzzer->exception), fuzzer->pc,
-                 fuzzer->backtrace, fuzzer->access, fuzzer->origFileName,
-                 hfuzz->fileExtn);
+                 fuzzer->backtrace, fuzzer->access, hfuzz->fileExtn);
     } else {
         char localtmstr[PATH_MAX];
         util_getLocalTime("%F.%H.%M.%S", localtmstr, sizeof(localtmstr), time(NULL));
 
         snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
-                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.TIME.%s.PID.%.5d.%s.%s",
+                 "%s/%s.%s.PC.%.16llx.STACK.%.16llx.ADDR.%.16llx.TIME.%s.PID.%.5d.%s",
                  hfuzz->workDir, arch_sigs[termsig].descr,
                  exception_to_string(fuzzer->exception), fuzzer->pc,
-                 fuzzer->backtrace, fuzzer->access, localtmstr, fuzzer->pid,
-                 fuzzer->origFileName, hfuzz->fileExtn);
+                 fuzzer->backtrace, fuzzer->access, localtmstr, fuzzer->pid, hfuzz->fileExtn);
     }
 
     if (files_exists(fuzzer->crashFileName)) {

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -147,6 +147,26 @@ const char *exception_to_string(int exception)
     return "UNKNOWN";
 }
 
+static void arch_generateReport(fuzzer_t * fuzzer, int termsig)
+{
+    fuzzer->report[0] = '\0';
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "ORIG_FNAME: %s\n",
+                   fuzzer->origFileName);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FUZZ_FNAME: %s\n",
+                   fuzzer->crashFileName);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "PID: %d\n", fuzzer->pid);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "SIGNAL: %s (%d)\n",
+                   arch_sigs[termsig].descr, termsig);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "EXCEPTION: %s\n",
+                   exception_to_string(fuzzer->exception));
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FAULT ADDRESS: %p\n", fuzzer->access);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "CRASH FRAME PC: %p\n", fuzzer->pc);
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "STACK HASH: %016llx\n",
+                   fuzzer->backtrace);
+
+    return;
+}
+
 /*
  * Returns true if a process exited (so, presumably, we can delete an input
  * file)
@@ -256,6 +276,8 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
     ATOMIC_POST_INC(hfuzz->uniqueCrashesCnt);
     /* If unique crash found, reset dynFile counter */
     ATOMIC_CLEAR(hfuzz->dynFileIterExpire);
+
+    arch_generateReport(fuzzer, termsig);
 
     return true;
 }


### PR DESCRIPTION
Has the same volume of information as the Linux ptrace arch, except the crashing frame stack traces. Since on MAC that information is available from crash wrangler as a huge description string, it needs some manual (and painful) string parsing and thus is not implemented yet.

If for some reason that information is required, users can enable file logging and compile with debug flag where the `write_crash_report()` function will be activated and write entire crash dump in file log.

This PR is also removing the recently added original seed filename info in crash file name, since it creates very large names are not very practical and might get truncated due to size limits. That information is available in the report now.