### PR TITLE
Fix race condition when writing the report.

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -199,6 +199,8 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         .covMetadata = NULL,
         .msanReportUMRS = false,
 
+        .report_mutex = PTHREAD_MUTEX_INITIALIZER,
+
         /* Linux code */
         .linux = {
             .hwCnts = {

--- a/common.h
+++ b/common.h
@@ -283,6 +283,8 @@ typedef struct {
     node_t *covMetadata;
     bool msanReportUMRS;
 
+    pthread_mutex_t report_mutex;
+
     /* For the Linux code */
     struct {
         hwcnt_t hwCnts;

--- a/fuzz.c
+++ b/fuzz.c
@@ -625,7 +625,10 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         }
     }
 
-    report_Report(hfuzz, fuzzer->report);
+    {
+        MX_SCOPED_LOCK(&hfuzz->report_mutex);
+        report_Report(hfuzz, fuzzer->report);
+    }
 
     if (state == _HF_STATE_DYNAMIC_PRE && ATOMIC_PRE_INC(hfuzz->doneFileIndex) >= hfuzz->fileCnt) {
         fuzz_setState(hfuzz, _HF_STATE_DYNAMIC_MAIN);


### PR DESCRIPTION
With more than 1 threads fuzzing it is possible to end up with a garbled report file.
To reproduce this I tried with a high number of threads (>10) and ended up with a report that looked like this:

```
=====================================================================
TIME: 2016-05-09.21:47:15
=====================================================================
FUZZER ARGS:
 flipRate     : 0.001000
 externalCmd  : NULL
 fuzzStdin    : FALSE
 timeout      : 10 (sec)
 ignoreAddr   : 0x0 
 memoryLimit  : 0 (MiB)
 targetPid    : 0 
 targetCmd    : (null)
 wordlistFile : NULL
 fuzzTarget   : examples/targets/badcode1 ___FILE___ 
=====================================================================
TIME: 2016-05-09.21:47:17
=====================================================================
FUZZER ARGS:
 flipRate     : 0.001000
 externalCmd  : NULL
 fuzzStdin    : FALSE
 timeout      : 10 (sec)
 ignoreAddr   : 0x0 
 memoryLimit  : 0 (MiB)
 targetPid    : 0 
 targetCmd    : (null)
 wordlistFile : NULL
 fuzzTarget   : examples/targets/badcode1 ___FILE___ 
ORIG_FNAME: badcode1.txt
FUZZ_FNAME: ./SIGSEGV.EXC_BAD_ACCESS.PC.00007fff9b0e70a5.STACK.00000014e6d38d7d.ADDR.0000000000000000.fuzz
PID: 27291
SIGNAL: SIGSEGV (11)
EXCEPTION: EXC_BAD_ACCESS
FAULT ADDRESS: 0x0 
CRASH FRAME PC: 0x7fff9b0e70a5
STACK HASH: 00000014e6d38d7d
=====================================================================
ORIG_FNAME: badcode1.txt
FUZZ_FNAME: ./SIGSEGV.EXC_BAD_ACCESS.PC.00007fff9b0e70a5.STACK.00000015e2b31df9.ADDR.0000000000000000.fuzz
PID: 27271
SIGNAL: SIGSEGV (11)
EXCEPTION: EXC_BAD_ACCESS
FAULT ADDRESS: 0x0 
CRASH FRAME PC: 0x7fff9b0e70a5
STACK HASH: 00000015e2b31df9
=====================================================================
```

Notice how the first crash is actually split in half.
