### PR TITLE
Update sancov.c

### DIFF
--- a/sancov.c
+++ b/sancov.c
@@ -453,6 +453,7 @@ static bool sancov_sanCovParseRaw(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         if (prevMapsNum == 0 || prevMapsNum < mapsNum) {
             if ((mapsBuf = realloc(mapsBuf, (size_t) (mapsNum + 1) * sizeof(memMap_t))) == NULL) {
                 PLOG_E("realloc failed (sz=%" PRIu64 ")", (mapsNum + 1) * sizeof(memMap_t));
+                free(mapsBuf);
                 return false;
             }
         }


### PR DESCRIPTION
[[../honggfuzz-master/sancov.c:454](https://github.com/google/honggfuzz/blob/master/sancov.c#L454)]: (error) Common realloc mistake: 'mapsBuf' nulled but not freed upon failure

**[This solution](http://stackoverflow.com/a/1607031) from Stack Overflow was helpful in fixing the error because if realloc cannot find enough space, it returns a null pointer, and leaves the previous region allocated.** 

Found by https://github.com/bryongloden/cppcheck