### PR TITLE
[ANDROID] Typo in makefile for arm-v7a clang toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ ifeq ($(ANDROID_CLANG),true)
   # clang works only for APIs >= 23, so default to it if not set
   ANDROID_API ?= android-24
   ifeq ($(ANDROID_APP_ABI),armeabi-v7a)
-    ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-4.9
+    ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-clang
   else ifeq ($(ANDROID_APP_ABI),x86)
     ANDROID_NDK_TOOLCHAIN ?= x86-clang
   else ifeq ($(ANDROID_APP_ABI),arm64-v8a)


### PR DESCRIPTION
When toolchains upgraded to match Android NDK r12 format (clang version removed from toolchain suffix), a small typo for the armeabi-v7a target was resulting into wrongly choosing the GCC 4.9 toolchain when CLANG flag was enabled.

```
anestisb@nemesis:[honggfuzz]: ndk-build NDK_TOOLCHAIN=?
Android NDK: NDK_TOOLCHAIN is defined to the unsupported value ?
Android NDK: Please use one of the following values: aarch64-linux-android-4.9 aarch64-linux-android-clang arm-linux-androideabi-4.9 arm-linux-androideabi-clang mips64el-linux-android-4.9 mips64el-linux-android-clang mipsel-linux-android-4.9 mipsel-linux-android-clang x86-4.9 x86-clang x86_64-4.9 x86_64-clang
/Users/anestisb/Developer/android/android-ndk-r12b/build/core/init.mk:613: *** Android NDK: Aborting    .  Stop.
```