### PR TITLE
display alignment and fix liblzma bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(OS),Linux)
                    -Wno-unknown-warning-option -funroll-loops \
                    -D_FILE_OFFSET_BITS=64
     ARCH_LDFLAGS := -L/usr/local/include -L/usr/include \
-                    -lpthread -lunwind-ptrace -lunwind-generic -lbfd -lopcodes -lrt
+                    -lpthread -lunwind-ptrace -llzma -lunwind-generic -lbfd -lopcodes -lrt
     ARCH_SRCS := $(wildcard linux/*.c)
 
     ifeq ("$(wildcard /usr/include/bfd.h)","")

--- a/display.c
+++ b/display.c
@@ -140,7 +140,7 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
     display_put("%s", ESC_CLEAR);
     display_put("-----------------------------[ %s v%s ]-----------------------------\n", PROG_NAME,
                 PROG_VERSION);
-    display_put("Iterations: " ESC_BOLD "%" _HF_MONETARY_MOD "zu" ESC_RESET, curr_exec_cnt);
+    display_put("      Iterations : " ESC_BOLD "%" _HF_MONETARY_MOD "zu" ESC_RESET, curr_exec_cnt);
     display_printKMG(curr_exec_cnt);
     if (hfuzz->mutationsMax) {
         display_put(" (out of: " ESC_BOLD "%zu" ESC_RESET " [" ESC_BOLD "%.2f" ESC_RESET
@@ -148,40 +148,40 @@ static void display_displayLocked(honggfuzz_t * hfuzz)
     }
     char start_time_str[128];
     util_getLocalTime("%F %T", start_time_str, sizeof(start_time_str), hfuzz->timeStart);
-    display_put("\nRun time: " ESC_BOLD "%s" ESC_RESET " (since: " ESC_BOLD "%s" ESC_RESET
+    display_put("\n        Run Time : " ESC_BOLD "%s" ESC_RESET " (since: " ESC_BOLD "%s" ESC_RESET
                 ")\n", time_elapsed_str, start_time_str);
-    display_put("Input file/dir: '" ESC_BOLD "%s" ESC_RESET "'\n", hfuzz->inputFile);
-    display_put("Fuzzed cmd: '" ESC_BOLD "%s" ESC_RESET "'\n", hfuzz->cmdline_txt);
+    display_put("  Input File/Dir : '" ESC_BOLD "%s" ESC_RESET "'\n", hfuzz->inputFile);
+    display_put("      Fuzzed Cmd : '" ESC_BOLD "%s" ESC_RESET "'\n", hfuzz->cmdline_txt);
     if (hfuzz->linux.pid > 0) {
         display_put("Remote cmd [" ESC_BOLD "%d" ESC_RESET "]: '" ESC_BOLD "%s" ESC_RESET
                     "'\n", hfuzz->linux.pid, hfuzz->linux.pidCmd);
     }
 
     double cpuUse = getCpuUse();
-    display_put("Fuzzing threads: " ESC_BOLD "%zu" ESC_RESET ", CPUs: " ESC_BOLD "%ld" ESC_RESET
+    display_put(" Fuzzing Threads : " ESC_BOLD "%zu" ESC_RESET ", CPUs: " ESC_BOLD "%ld" ESC_RESET
                 ", CPU: " ESC_BOLD "%.1lf" ESC_RESET "%% (" ESC_BOLD "%.1lf" ESC_RESET "%%/CPU)\n",
                 hfuzz->threadsMax, sysconf(_SC_NPROCESSORS_ONLN), cpuUse,
                 cpuUse / sysconf(_SC_NPROCESSORS_ONLN));
 
-    display_put("%s per second: " ESC_BOLD "% " _HF_MONETARY_MOD "zu" ESC_RESET
+    display_put("     %s Speed : " ESC_BOLD "% "  _HF_MONETARY_MOD "zu" ESC_BOLD "/sec" ESC_RESET
                 " (avg: " ESC_BOLD "%" _HF_MONETARY_MOD "zu" ESC_RESET ")\n",
                 hfuzz->persistent ? "Rounds" : "Execs", exec_per_sec,
                 elapsed_second ? (curr_exec_cnt / elapsed_second) : 0);
     /* If dry run, print also the input file count */
     if (hfuzz->origFlipRate == 0.0L && hfuzz->useVerifier) {
-        display_put("Input Files: '" ESC_BOLD "%" _HF_MONETARY_MOD "zu" ESC_RESET "'\n",
+        display_put("     Input Files : '" ESC_BOLD "%" _HF_MONETARY_MOD "zu" ESC_RESET "'\n",
                     hfuzz->fileCnt);
     }
 
     uint64_t crashesCnt = ATOMIC_GET(hfuzz->crashesCnt);
     /* colored the crash count as red when exist crash */
-    display_put("Crashes: " ESC_BOLD "%s" "%zu" ESC_RESET " (unique: %s" ESC_BOLD "%zu"
+    display_put("         Crashes : " ESC_BOLD "%s" "%zu" ESC_RESET " (unique: %s" ESC_BOLD "%zu"
                 ESC_RESET ", blacklist: " ESC_BOLD "%zu" ESC_RESET ", verified: "
                 ESC_BOLD "%zu" ESC_RESET ")\n", crashesCnt > 0 ? ESC_RED : "",
                 hfuzz->crashesCnt, crashesCnt > 0 ? ESC_RED : "",
                 ATOMIC_GET(hfuzz->uniqueCrashesCnt), ATOMIC_GET(hfuzz->blCrashesCnt),
                 ATOMIC_GET(hfuzz->verifiedCrashesCnt));
-    display_put("Timeouts (%" _HF_MONETARY_MOD "zu sec): " ESC_BOLD "%"
+    display_put("Timeouts (%" _HF_MONETARY_MOD "zu sec) : " ESC_BOLD "%"
                 _HF_MONETARY_MOD "zu" ESC_RESET "\n", hfuzz->tmOut,
                 ATOMIC_GET(hfuzz->timeoutedCnt));
     /* Feedback data sources are enabled. Start with common headers. */


### PR DESCRIPTION
fix the bug that liblzma library symbols not found in ubuntu, and display alignment.

the liblzma bug only in some ubuntu env, beacause ld error when compiling libunwind, it can't found some liblzma functions symbols, for example "Symbol not found: _lzma_auto_XXX".
add `-lzma` can to avoid the above problems, but this bug only appeared on my an ubuntu virtual.

Before:
```
=============================| honggfuzz v.0.8rc |============================
Iterations: 63862 [63.86k]
Run time: 15 hrs 22 min 7 sec (since: 2016-09-09 23:19:59)
Input file/dir: '/Users/riusksk/Downloads/mp4'
Fuzzed cmd: '/Applications/test.app/Contents/MacOS/test ___FILE___'
Fuzzing threads: 5, CPUs: 4, CPU: nan% (nan%/CPU)
Execs per second: 0 (avg: 1)
Crashes: 8 (unique: 3, blacklist: 0, verified: 0)
Timeouts (4 sec): 0
==================================| LOGS |====================================
```

After:
```
-----------------------------[ honggfuzz v0.8rc ]-----------------------------
      Iterations : 5
        Run Time : 0 hrs 0 min 3 sec (since: 2016-09-10 16:00:17)
  Input File/Dir : '/Users/riusksk/Downloads/mp4'
      Fuzzed Cmd : '/Applications/test.app/Contents/MacOS/test ___FILE___'
 Fuzzing Threads : 5, CPUs: 4, CPU: nan% (nan%/CPU)
     Execs Speed : 0/sec (avg: 1)
         Crashes : 0 (unique: 0, blacklist: 0, verified: 0)
Timeouts (4 sec) : 0
-----------------------------------[ LOGS ]-----------------------------------
```