### PR TITLE
not allowed to use colon in Windows file path

### DIFF
--- a/posix/arch.c
+++ b/posix/arch.c
@@ -110,7 +110,7 @@ static bool arch_analyzeSignal(honggfuzz_t * hfuzz, int status, fuzzer_t * fuzze
     }
 
     char localtmstr[PATH_MAX];
-    util_getLocalTime("%F.%H:%M:%S", localtmstr, sizeof(localtmstr), time(NULL));
+    util_getLocalTime("%F.%H.%M.%S", localtmstr, sizeof(localtmstr), time(NULL));
 
     char newname[PATH_MAX];
 


### PR DESCRIPTION
in Windows, not allowed to use colon in file path.
the colon would be replaced with blank space if use colon.