### PR TITLE
[Android] Adjust makefile for NDK R13 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ ifeq ($(DEBUG),true)
 endif
 
 # Control Android builds
+ANDROID_API           ?= android-24
 ANDROID_DEBUG_ENABLED ?= false
 ANDROID_CLANG         ?= false
 ANDROID_APP_ABI       ?= armeabi-v7a
@@ -158,22 +159,30 @@ ifeq ($(ANDROID_DEBUG_ENABLED),true)
 endif
 
 ifeq ($(ANDROID_CLANG),true)
-  # clang works only for APIs >= 23, so default to it if not set
-  ANDROID_API ?= android-24
-  ifeq ($(ANDROID_APP_ABI),armeabi-v7a)
+  # clang works only against APIs >= 23
+  ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),armeabi armeabi-v7a))
     ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-clang
-  else ifeq ($(ANDROID_APP_ABI),x86)
+  else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86))
     ANDROID_NDK_TOOLCHAIN ?= x86-clang
-  else ifeq ($(ANDROID_APP_ABI),arm64-v8a)
+  else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),arm64-v8a))
     ANDROID_NDK_TOOLCHAIN ?= aarch64-linux-android-clang
-  else ifeq ($(ANDROID_APP_ABI),x86_64)
+  else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86_64))
     ANDROID_NDK_TOOLCHAIN ?= x86_64-clang
   else
     $(error Unsuported / Unknown APP_API '$(ANDROID_APP_ABI)')
   endif
 else
-  ANDROID_API           ?= android-24
-  ANDROID_NDK_TOOLCHAIN ?=
+  ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),armeabi armeabi-v7a))
+    ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-4.9
+  else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86))
+    ANDROID_NDK_TOOLCHAIN ?= x86-4.9
+  else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),arm64-v8a))
+    ANDROID_NDK_TOOLCHAIN ?= aarch64-linux-android-4.9
+  else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86_64))
+    ANDROID_NDK_TOOLCHAIN ?= x86_64-4.9
+  else
+    $(error Unsuported / Unknown APP_API '$(ANDROID_APP_ABI)')
+  endif
 endif
 
 SUBDIR_ROOTS := linux mac posix libhfuzz


### PR DESCRIPTION
GCC compatibility is deprecated across the entire Android ecosystem
including the provided NDK toolchains. As explained in R13 changelog
GCC is no longer supported, although not remove yet [1].

Since CLANG toolchains are the new defaults, adjust makefile selection in
order to be aligned with ANDROID_CLANG flag value and be backwards
compatible with older NDKs that include GCC version 4.9

Honggfuzz was defaulting to GCC and both unwinding & ptrace backends
have been heavily tested against it. CLANG was also supported, although
not tested at the same extend. As such don't default to CLANG for now
until some more testing is performed.

[1] https://developer.android.com/ndk/downloads/index.html#rel