### PR TITLE
Bug fix: util_rndBuf was generating only 0 or 1 value

### DIFF
--- a/util.c
+++ b/util.c
@@ -127,7 +127,7 @@ uint64_t util_rndGet(uint64_t min, uint64_t max)
 void util_rndBuf(uint8_t * buf, size_t sz)
 {
     for (size_t i = 0; i < sz; i++) {
-        buf[i] = (uint8_t) ((util_rnd64() & 0xFF0000) > 16);
+        buf[i] = (uint8_t) ((util_rnd64() & 0xFF0000) >> 16);
     }
 }
 


### PR DESCRIPTION
I'm not sure what's your intention. I think you tried to pick a third byte from rightmost side and shift it. But, the current code is comparing with 16, not shifting, thus it only generates 0 or 1 (mostly 1).