### PR TITLE
keep fuzzed file orig file ext

### DIFF
--- a/common.h
+++ b/common.h
@@ -289,7 +289,7 @@ typedef struct {
     const char *origFileName;
     char fileName[PATH_MAX];
     char crashFileName[PATH_MAX];
-    char ext[PATH_MAX];
+    char ext[NAME_MAX];
     uint64_t pc;
     uint64_t backtrace;
     uint64_t access;

--- a/common.h
+++ b/common.h
@@ -289,6 +289,7 @@ typedef struct {
     const char *origFileName;
     char fileName[PATH_MAX];
     char crashFileName[PATH_MAX];
+    char ext[PATH_MAX];
     uint64_t pc;
     uint64_t backtrace;
     uint64_t access;

--- a/fuzz.c
+++ b/fuzz.c
@@ -508,8 +508,9 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 	//printf("ext: %s\n",fuzzer->ext);
 	
     }
-    
-    hfuzz->fileExtn = fuzzer->ext;
+    if(!strcmp(hfuzz->fileExtn, "*")){ 
+    	hfuzz->fileExtn = fuzzer->ext;
+    }
     fuzz_getFileName(hfuzz, fuzzer->fileName);
 
     if (state == _HF_STATE_DYNAMIC_PRE) {

--- a/fuzz.c
+++ b/fuzz.c
@@ -63,11 +63,6 @@ static void fuzz_getFileName(honggfuzz_t * hfuzz, char *fileName)
              (int)getpid(), (unsigned long int)tv.tv_sec, util_rnd64(), hfuzz->fileExtn);
 }
 
-void fuzz_getExtension(const char *file_name,char *extension)  
-{  
-    extension = strrchr(file_name, '.' );   
-}
-
 static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 {
     struct dynfile_t *dynfile;
@@ -492,10 +487,7 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     fuzzState_t state = fuzz_getState(hfuzz);
     if (state != _HF_STATE_DYNAMIC_MAIN) {
         fuzzer->origFileName = files_basename(files_getFileFromFileq(hfuzz, rnd_index)->path);
-	//printf("origFileName: %s\n",fuzzer->origFileName);
-	fuzz_getExtension(fuzzer->origFileName, fuzzer->ext);
-	//printf("ext: %s\n",fuzzer->ext);
-	
+	fuzzer->ext = strrchr(fuzzer->origFileName, '.' );	
     }
     if(!strcmp(hfuzz->fileExtn, "any")){ 
     	hfuzz->fileExtn = fuzzer->ext;

--- a/fuzz.c
+++ b/fuzz.c
@@ -63,6 +63,22 @@ static void fuzz_getFileName(honggfuzz_t * hfuzz, char *fileName)
              (int)getpid(), (unsigned long int)tv.tv_sec, util_rnd64(), hfuzz->fileExtn);
 }
 
+void fuzz_getExtension(const char *file_name,char *extension)  
+{  
+    int i=0,length;  
+    length=strlen(file_name);  
+        while(file_name[i])  
+    {  
+        if(file_name[i]=='.')  
+        break;  
+        i++;  
+    }  
+    if(i<length)  
+    strcpy(extension,file_name+i+1);  
+    else  
+    strcpy(extension,"\0");  
+}
+
 static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 {
     struct dynfile_t *dynfile;
@@ -487,8 +503,13 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     fuzzState_t state = fuzz_getState(hfuzz);
     if (state != _HF_STATE_DYNAMIC_MAIN) {
         fuzzer->origFileName = files_basename(files_getFileFromFileq(hfuzz, rnd_index)->path);
+	//printf("origFileName: %s\n",fuzzer->origFileName);
+	fuzz_getExtension(fuzzer->origFileName, fuzzer->ext);
+	//printf("ext: %s\n",fuzzer->ext);
+	
     }
-
+    
+    hfuzz->fileExtn = fuzzer->ext;
     fuzz_getFileName(hfuzz, fuzzer->fileName);
 
     if (state == _HF_STATE_DYNAMIC_PRE) {

--- a/fuzz.c
+++ b/fuzz.c
@@ -65,18 +65,7 @@ static void fuzz_getFileName(honggfuzz_t * hfuzz, char *fileName)
 
 void fuzz_getExtension(const char *file_name,char *extension)  
 {  
-    int i=0,length;  
-    length=strlen(file_name);  
-        while(file_name[i])  
-    {  
-        if(file_name[i]=='.')  
-        break;  
-        i++;  
-    }  
-    if(i<length)  
-    strcpy(extension,file_name+i+1);  
-    else  
-    strcpy(extension,"\0");  
+    extension = strrchr(file_name, '.' );   
 }
 
 static bool fuzz_prepareFileDynamically(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)

--- a/fuzz.c
+++ b/fuzz.c
@@ -508,7 +508,7 @@ static void fuzz_fuzzLoop(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 	//printf("ext: %s\n",fuzzer->ext);
 	
     }
-    if(!strcmp(hfuzz->fileExtn, "*")){ 
+    if(!strcmp(hfuzz->fileExtn, "any")){ 
     	hfuzz->fileExtn = fuzzer->ext;
     }
     fuzz_getFileName(hfuzz, fuzzer->fileName);


### PR DESCRIPTION
it can fuzzing the mulitple file format in the same time, for example, some image file(*.png, *.gif, *.jpg...) in the following file dir:

`honggfuzz -f file -e any -- imageview ___FILE___`

Some app must only parse the specific file suffix name.,but the default generated file suffix name is *.fuzz, and -e arg can only specify a file suffix, so the fuzzing would be invalid when input dir have multiple file suffix name.