### PR TITLE
Fix submodule init bug when non-recursive clone

### DIFF
--- a/third_party/android/scripts/compile-capstone.sh
+++ b/third_party/android/scripts/compile-capstone.sh
@@ -31,7 +31,7 @@ fi
 
 readonly CAPSTONE_DIR=$1
 
-if [ ! -d "$CAPSTONE_DIR" ]; then
+if [ ! -d "$CAPSTONE_DIR/.git" ]; then
   git submodule update --init third_party/android/capstone || {
     echo "[-] git submodules init failed"
     exit 1

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -47,7 +47,7 @@ fi
 # Change workspace
 readonly LIBUNWIND_DIR="$1"
 
-if [ ! -d "$LIBUNWIND_DIR" ]; then
+if [ ! -d "$LIBUNWIND_DIR/.git" ]; then
   git submodule update --init third_party/android/libunwind || {
     echo "[-] git submodules init failed"
     exit 1


### PR DESCRIPTION
When user clones repo without submodules, by default most
git versions appear to create just an empty directory for them. As
such just checking if directory present to init submodules is not
enough. Checks have been upgraded to use the presence of
projects' `.git` dir as an indicator for missing submodule initialization.