### PR TITLE
[Android] Compile libhfuzz + android-all build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so
 *.dylib
 *.dSYM
+*.a
 honggfuzz
 mac/mach_exc.h
 mac/mach_excUser.c


### PR DESCRIPTION
libhfuzz is compiled as static library using the BUILD_STATIC_LIBRARY
template from Android NDK. The static library is added as "virtual"
dependency to main honggfuzz module, otherwise the build system
will ignore it since it detects that the module target is not used. The
libhfuzz extra cflags are matching the ones from master Makefile. Testing
of the libhfuzz is still pending since it requires clang 4.0 while Android is
still defaulting to 3.8.

Also tided-up a little bit the Android.mk so that common configuration is
shared at the top of the file for both target modules.

Finally an additional post build step was required to copy the generated
.a file into the project dir so that both output files are under the same file.
Static libraries compiled from NDK templates are not automatically added
to project output dirs since they purposed for internal dependencies by
default.

Added an extra 'android-all' rule to compile all supported ABI targets at
once. Supported flags are passed-through the make subprocesses so
that same level of control is achieved.