### PR TITLE
[MAC] Fix missing symbol bug

### DIFF
--- a/mac/arch.c
+++ b/mac/arch.c
@@ -362,6 +362,10 @@ bool arch_launchChild(honggfuzz_t * hfuzz, char *fileName)
     return false;
 }
 
+void arch_prepareChild(honggfuzz_t * hfuzz UNUSED, fuzzer_t * fuzzer UNUSED)
+{
+}
+
 void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 {
     /*


### PR DESCRIPTION
Fixes the following. Not sure what ordering voodoo
where taking place before the previous commit that
were not triggering the issue at compile time.

Undefined symbols for architecture x86_64:
  "_arch_prepareChild", referenced from:
      _subproc_Run in subproc.o
ld: symbol(s) not found for architecture x86_64