### PR TITLE
[Android] Improve deps compilation automation & error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,18 @@ android-all:
 	  echo ""; \
 	done
 
+.PHONY: android-clean-deps
+android-clean-deps:
+	@for cpu in arm arm64 x86 x86_64; do \
+	  make -C "third_party/android/capstone" clean; \
+	  rm -rf "third_party/android/capstone/$$cpu"; \
+	  make -C "third_party/android/libunwind" clean; \
+	  rm -rf "third_party/android/libunwind/$$cpu"; \
+	  ndk-build -C "third_party/android/libBlocksRuntime" \
+	    NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=Android.mk clean; \
+	  rm -rf "third_party/android/libBlocksRuntime/$$cpu"; \
+	done
+
 # DO NOT DELETE
 
 cmdline.o: cmdline.h common.h log.h files.h util.h

--- a/Makefile
+++ b/Makefile
@@ -176,24 +176,32 @@ ifeq ($(ANDROID_CLANG),true)
   # clang works only against APIs >= 23
   ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),armeabi armeabi-v7a))
     ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-clang
+    ANDROID_ARCH_CPU := arm
   else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86))
     ANDROID_NDK_TOOLCHAIN ?= x86-clang
+    ANDROID_ARCH_CPU := x86
   else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),arm64-v8a))
     ANDROID_NDK_TOOLCHAIN ?= aarch64-linux-android-clang
+    ANDROID_ARCH_CPU := arm64
   else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86_64))
     ANDROID_NDK_TOOLCHAIN ?= x86_64-clang
+    ANDROID_ARCH_CPU := x86_64
   else
     $(error Unsuported / Unknown APP_API '$(ANDROID_APP_ABI)')
   endif
 else
   ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),armeabi armeabi-v7a))
     ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-4.9
+    ANDROID_ARCH_CPU := arm
   else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86))
     ANDROID_NDK_TOOLCHAIN ?= x86-4.9
+    ANDROID_ARCH_CPU := x86
   else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),arm64-v8a))
     ANDROID_NDK_TOOLCHAIN ?= aarch64-linux-android-4.9
+    ANDROID_ARCH_CPU := arm64
   else ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),x86_64))
     ANDROID_NDK_TOOLCHAIN ?= x86_64-4.9
+    ANDROID_ARCH_CPU := x86_64
   else
     $(error Unsuported / Unknown APP_API '$(ANDROID_APP_ABI)')
   endif
@@ -240,6 +248,17 @@ depend:
 
 .PHONY: android
 android:
+	@ANDROID_API=$(ANDROID_API) third_party/android/scripts/compile-libunwind.sh \
+	third_party/android/libunwind $(ANDROID_ARCH_CPU)
+
+	@ANDROID_API=$(ANDROID_API) third_party/android/scripts/compile-capstone.sh \
+	third_party/android/capstone $(ANDROID_ARCH_CPU)
+
+  ifeq ($(ANDROID_CLANG),true)
+		@ANDROID_API=$(ANDROID_API) third_party/android/scripts/compile-libBlocksRuntime.sh \
+		third_party/android/libBlocksRuntime $(ANDROID_ARCH_CPU)
+  endif
+
 	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./android/Android.mk \
     APP_PLATFORM=$(ANDROID_API) APP_ABI=$(ANDROID_APP_ABI) \
     NDK_TOOLCHAIN=$(ANDROID_NDK_TOOLCHAIN) $(NDK_BUILD_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ else ifeq ($(OS),Darwin)
     # Figure out which crash reporter to use.
     CRASHWRANGLER := third_party/mac
     OS_VERSION := $(shell sw_vers -productVersion)
-	ifneq (,$(findstring 10.12,$(OS_VERSION)))
-		CRASH_REPORT := $(CRASHWRANGLER)/CrashReport_Yosemite.o
+    ifneq (,$(findstring 10.12,$(OS_VERSION)))
+        CRASH_REPORT := $(CRASHWRANGLER)/CrashReport_Yosemite.o
     else ifneq (,$(findstring 10.11,$(OS_VERSION)))
         # El Capitan didn't break compatibility
         CRASH_REPORT := $(CRASHWRANGLER)/CrashReport_Yosemite.o

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -21,16 +21,12 @@ ANDROID_WITH_PTRACE ?= true
 ifeq ($(ANDROID_WITH_PTRACE),true)
   ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi armeabi-v7a))
     ARCH_ABI := arm
-    UNW_ARCH := arm
   else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86))
     ARCH_ABI := x86
-    UNW_ARCH := x86
   else ifeq ($(APP_ABI),$(filter $(APP_ABI),arm64-v8a))
     ARCH_ABI := arm64
-    UNW_ARCH := aarch64
   else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86_64))
     ARCH_ABI := x86_64
-    UNW_ARCH := x86_64
   else
     $(error Unsuported / Unknown APP_API '$(APP_ABI)')
   endif
@@ -43,9 +39,9 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
   endif
 
   # Upstream libunwind compiled from sources with Android NDK toolchain
-  LIBUNWIND_A := third_party/android/libunwind/$(ARCH_ABI)/libunwind-$(UNW_ARCH).a
+  LIBUNWIND_A := third_party/android/libunwind/$(ARCH_ABI)/libunwind-$(ARCH_ABI).a
   ifeq ("$(wildcard $(LIBUNWIND_A))","")
-    $(error libunwind-$(UNW_ARCH) is missing - to build execute \
+    $(error libunwind-$(ARCH_ABI) is missing - to build execute \
             'third_party/android/scripts/compile-libunwind.sh third_party/android/libunwind $(ARCH_ABI)')
   endif
 
@@ -57,7 +53,7 @@ ifeq ($(ANDROID_WITH_PTRACE),true)
 
   include $(CLEAR_VARS)
   LOCAL_MODULE := libunwind-arch
-  LOCAL_SRC_FILES := third_party/android/libunwind/$(ARCH_ABI)/libunwind-$(UNW_ARCH).a
+  LOCAL_SRC_FILES := third_party/android/libunwind/$(ARCH_ABI)/libunwind-$(ARCH_ABI).a
   LOCAL_EXPORT_C_INCLUDES := third_party/android/libunwind/include
   include $(PREBUILT_STATIC_LIBRARY)
 

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -15,6 +15,24 @@
 
 LOCAL_PATH := $(abspath $(call my-dir)/..)
 
+# Force a clean if target API has changed and a previous build exists
+ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt)","")
+  CACHED_API := $(shell cat "$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt")
+  ifneq ($(ANDROID_API),$(CACHED_API))
+    $(info [!] Previous build was targeting different API level - cleaning)
+    DUMMY_CLEAN := $(shell make clean)
+  endif
+endif
+
+# Force a clean if selected toolchain has changed and a previous build exists
+ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt)","")
+  CACHED_TOOLCHAIN := $(shell cat "$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt")
+  ifneq ($(NDK_TOOLCHAIN),$(CACHED_TOOLCHAIN))
+    $(info [!] Previous build was using different toolchain - cleaning)
+    DUMMY_CLEAN := $(shell make clean)
+  endif
+endif
+
 # Enable Linux ptrace() instead of POSIX signal interface by default
 ANDROID_WITH_PTRACE ?= true
 
@@ -161,9 +179,13 @@ endif
 include $(BUILD_EXECUTABLE)
 
 # The NDK build system does not copy static libraries into project/packages
-# so it has to be done manually in order to have all output under a single path
+# so it has to be done manually in order to have all output under a single path.
+# Also save some build attribute cache files so that cleans can be enforced when
+# required.
 all:POST_BUILD_EVENT
 POST_BUILD_EVENT:
+	@echo $(ANDROID_API) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt
+	@echo $(NDK_TOOLCHAIN) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt
 	@test -f $(LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a && \
 	  cp $(LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a \
 	    $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/libhfuzz.a || true

--- a/third_party/android/scripts/compile-capstone.sh
+++ b/third_party/android/scripts/compile-capstone.sh
@@ -66,7 +66,7 @@ if [ -z "$NDK" ]; then
     NDK=$(dirname $(which ndk-build))
   else
     echo "[-] Could not detect Android NDK dir"
-    exit 1
+    abort 1
   fi
 fi
 
@@ -77,7 +77,7 @@ case "$2" in
     ;;
   *)
     echo "[-] Invalid CPU architecture"
-    exit 1
+    abort 1
     ;;
 esac
 
@@ -116,12 +116,16 @@ if [ -z "$NDK" ]; then
     $NDK=$(dirname $(which ndk-build))
   else
     echo "[-] Could not detect Android NDK dir"
-    exit 1
+    abort 1
   fi
 fi
 
 if [ -z "$ANDROID_API" ]; then
   ANDROID_API="android-21"
+fi
+if ! echo "$ANDROID_API" | grep -qoE 'android-[0-9]{1,2}'; then
+  echo "[-] Invalid ANDROID_API '$ANDROID_API'"
+  abort 1
 fi
 
 # Support both Linux & Darwin
@@ -144,7 +148,7 @@ CAPSTONE_SHARED=no CAPSTONE_STATIC=yes \
 eval $CS_BUILD_BIN
 if [ $? -ne 0 ]; then
     echo "[-] Compilation failed"
-    exit 1
+    abort 1
 else
     echo "[*] '$ARCH' libcapstone available at '$CAPSTONE_DIR/$ARCH'"
 fi

--- a/third_party/android/scripts/compile-capstone.sh
+++ b/third_party/android/scripts/compile-capstone.sh
@@ -81,6 +81,18 @@ case "$2" in
     ;;
 esac
 
+# Check if previous build exists and matches selected ANDROID_API level
+# If API cache file not there always rebuild
+if [ -f "$ARCH/libcapstone.a" ]; then
+  if [ -f "$ARCH/android_api.txt" ]; then
+    old_api=$(cat "$ARCH/android_api.txt")
+    if [[ "$old_api" == "$ANDROID_API" ]]; then
+      # No need to recompile
+      abort 0
+    fi
+  fi
+fi
+
 case "$ARCH" in
   arm)
     CS_ARCH="arm"
@@ -153,6 +165,7 @@ else
     echo "[*] '$ARCH' libcapstone available at '$CAPSTONE_DIR/$ARCH'"
 fi
 
-cp libcapstone.a $ARCH/
+cp libcapstone.a "$ARCH/"
+echo "$ANDROID_API" > "$ARCH/android_api.txt"
 
 abort 0

--- a/third_party/android/scripts/compile-capstone.sh
+++ b/third_party/android/scripts/compile-capstone.sh
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-set -e # fail on unhandled error
 #set -x # debug
 
 abort() {

--- a/third_party/android/scripts/compile-capstone.sh
+++ b/third_party/android/scripts/compile-capstone.sh
@@ -15,6 +15,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+set -e # fail on unhandled error
+#set -x # debug
+
 abort() {
   cd - &>/dev/null
   exit "$1"
@@ -29,7 +32,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-readonly CAPSTONE_DIR=$1
+readonly CAPSTONE_DIR="$1"
 
 if [ ! -d "$CAPSTONE_DIR/.git" ]; then
   git submodule update --init third_party/android/capstone || {
@@ -117,11 +120,15 @@ if [ -z "$NDK" ]; then
   fi
 fi
 
+if [ -z "$ANDROID_API" ]; then
+  ANDROID_API="android-21"
+fi
+
 # Support both Linux & Darwin
 HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH=$(uname -m)
 
-SYSROOT="$NDK/platforms/android-21/arch-$ARCH"
+SYSROOT="$NDK/platforms/$ANDROID_API/arch-$ARCH"
 export CC="$NDK/toolchains/$TOOLCHAIN_S/prebuilt/$HOST_OS-$HOST_ARCH/bin/$TOOLCHAIN-gcc --sysroot=$SYSROOT"
 export CXX="$NDK/toolchains/$TOOLCHAIN_S/prebuilt/$HOST_OS-$HOST_ARCH/bin/$TOOLCHAIN-g++ --sysroot=$SYSROOT"
 export PATH="$NDK/toolchains/$TOOLCHAIN_S/prebuilt/$HOST_OS-$HOST_ARCH/bin":$PATH

--- a/third_party/android/scripts/compile-libBlocksRuntime.sh
+++ b/third_party/android/scripts/compile-libBlocksRuntime.sh
@@ -15,8 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-readonly ANDROID_API="android-23"
-
 if [ -z "$NDK" ]; then
   # Search in $PATH
   if [[ $(which ndk-build) != "" ]]; then
@@ -27,6 +25,10 @@ if [ -z "$NDK" ]; then
   fi
 fi
 
+if [ -z "$ANDROID_API" ]; then
+  ANDROID_API="android-23"
+fi
+
 if [ $# -ne 2 ]; then
   echo "[-] Invalid arguments"
   echo "[!] $0 <libBlocksRuntime_DIR> <ARCH>"
@@ -34,7 +36,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-readonly BRT_DIR=$1
+readonly BRT_DIR="$1"
 
 case "$2" in
   arm|arm64|x86|x86_64)

--- a/third_party/android/scripts/compile-libBlocksRuntime.sh
+++ b/third_party/android/scripts/compile-libBlocksRuntime.sh
@@ -28,6 +28,10 @@ fi
 if [ -z "$ANDROID_API" ]; then
   ANDROID_API="android-23"
 fi
+if ! echo "$ANDROID_API" | grep -qoE 'android-[0-9]{1,2}'; then
+  echo "[-] Invalid ANDROID_API '$ANDROID_API'"
+  exit 1
+fi
 
 if [ $# -ne 2 ]; then
   echo "[-] Invalid arguments"

--- a/third_party/android/scripts/compile-libBlocksRuntime.sh
+++ b/third_party/android/scripts/compile-libBlocksRuntime.sh
@@ -53,6 +53,18 @@ case "$2" in
     ;;
 esac
 
+# Check if previous build exists and matches selected ANDROID_API level
+# If API cache file not there always rebuild
+if [ -f "$BRT_DIR/$ARCH/libblocksruntime.a" ]; then
+  if [ -f "$BRT_DIR/$ARCH/android_api.txt" ]; then
+    old_api=$(cat "$BRT_DIR/$ARCH/android_api.txt")
+    if [[ "$old_api" == "$ANDROID_API" ]]; then
+      # No need to recompile
+      exit 0
+    fi
+  fi
+fi
+
 case "$ARCH" in
   arm)
     BRT_ARCH="armeabi-v7a"
@@ -91,7 +103,8 @@ fi
 # Change workdir to simplify args
 cd $BRT_DIR
 
-cp obj/local/$BRT_ARCH/libblocksruntime.a $ARCH/
+cp obj/local/$BRT_ARCH/libblocksruntime.a "$ARCH/"
+echo "$ANDROID_API" > "$ARCH/android_api.txt"
 
 # Revert workdir to caller
 cd - &>/dev/null

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -15,6 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+set -e # fail on unhandled error
 #set -x # debug
 
 abort() {
@@ -81,6 +82,10 @@ if [ -z "$NDK" ]; then
     echo "[-] Could not detect Android NDK dir"
     abort 1
   fi
+fi
+
+if [ -z "$ANDROID_API" ]; then
+  ANDROID_API="android-21"
 fi
 
 case "$2" in
@@ -180,7 +185,7 @@ fi
 HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH=$(uname -m)
 
-SYSROOT="$NDK/platforms/android-21/arch-$ARCH"
+SYSROOT="$NDK/platforms/$ANDROID_API/arch-$ARCH"
 export CC="$NDK/toolchains/$TOOLCHAIN_S/prebuilt/$HOST_OS-$HOST_ARCH/bin/$TOOLCHAIN-gcc --sysroot=$SYSROOT"
 export CXX="$NDK/toolchains/$TOOLCHAIN_S/prebuilt/$HOST_OS-$HOST_ARCH/bin/$TOOLCHAIN-g++ --sysroot=$SYSROOT"
 export PATH="$NDK/toolchains/$TOOLCHAIN_S/prebuilt/$HOST_OS-$HOST_ARCH/bin":$PATH

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -218,6 +218,18 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "[*] '$ARCH' libunwind available at '$LIBUNWIND_DIR/$ARCH'"
-cp src/.libs/*.a $ARCH
+cp src/.libs/*.a "$ARCH"
+
+# Naming conventions for arm64
+if [[ "$ARCH" == "arm64" ]]; then
+  cd "$ARCH"
+  find . -type f -name "*aarch64*.a" | while read -r libFile
+  do
+    fName=$(basename "$libFile")
+    newFName=$(echo "$fName" | sed "s#aarch64#arm64#")
+    ln -sf "$fName" "$newFName"
+  done
+  cd -
+fi
 
 abort 0

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-set -e # fail on unhandled error
 #set -x # debug
 
 abort() {

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -87,6 +87,10 @@ fi
 if [ -z "$ANDROID_API" ]; then
   ANDROID_API="android-21"
 fi
+if ! echo "$ANDROID_API" | grep -qoE 'android-[0-9]{1,2}'; then
+  echo "[-] Invalid ANDROID_API '$ANDROID_API'"
+  abort 1
+fi
 
 case "$2" in
   arm|arm64|x86|x86_64)


### PR DESCRIPTION
* Build all deps with same Android API level used to build the main tool
* Force clean builds when API level changes & previous objs exist
* Force clean builds when NDK toolchain changes & previous objs exist
* Automatically build deps from master makefile
 * If target exists & matches selected build config don't rebuild
* Add clean all target for Android deps
* Improve error handling at deps compilation scripts