### PR TITLE
[Android] Fix makefile minor bugs

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -18,7 +18,7 @@ LOCAL_PATH := $(abspath $(call my-dir)/..)
 # Force a clean if target API has changed and a previous build exists
 ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt)","")
   CACHED_API := $(shell cat "$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt")
-  ifneq ($(ANDROID_API),$(CACHED_API))
+  ifneq ($(APP_PLATFORM),$(CACHED_API))
     $(info [!] Previous build was targeting different API level - cleaning)
     DUMMY_CLEAN := $(shell make clean)
   endif
@@ -184,7 +184,7 @@ include $(BUILD_EXECUTABLE)
 # required.
 all:POST_BUILD_EVENT
 POST_BUILD_EVENT:
-	@echo $(ANDROID_API) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt
+	@echo $(APP_PLATFORM) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt
 	@echo $(NDK_TOOLCHAIN) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt
 	@test -f $(LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a && \
 	  cp $(LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a \

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -16,20 +16,23 @@
 LOCAL_PATH := $(abspath $(call my-dir)/..)
 
 # Force a clean if target API has changed and a previous build exists
+CLEAN_RUN := false
 ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt)","")
   CACHED_API := $(shell cat "$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt")
   ifneq ($(APP_PLATFORM),$(CACHED_API))
     $(info [!] Previous build was targeting different API level - cleaning)
-    DUMMY_CLEAN := $(shell make clean)
+    CLEAN_RUN := $(shell make clean &>/dev/null && echo true || echo false)
   endif
 endif
 
 # Force a clean if selected toolchain has changed and a previous build exists
-ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt)","")
-  CACHED_TOOLCHAIN := $(shell cat "$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt")
-  ifneq ($(NDK_TOOLCHAIN),$(CACHED_TOOLCHAIN))
-    $(info [!] Previous build was using different toolchain - cleaning)
-    DUMMY_CLEAN := $(shell make clean)
+ifeq ($(CLEAN_RUN),false)
+  ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt)","")
+    CACHED_TOOLCHAIN := $(shell cat "$(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt")
+    ifneq ($(NDK_TOOLCHAIN),$(CACHED_TOOLCHAIN))
+      $(info [!] Previous build was using different toolchain - cleaning)
+      CLEAN_RUN := $(shell make clean &>/dev/null && echo true || echo false)
+    endif
   endif
 endif
 


### PR DESCRIPTION
#### Android makefile should use APP_PLATFORM
ANDROID_API is not always visible for Android.mk, thus not safe to be used. Prefer APP_PLATFORM which is always set due the way ndk-build is invoked from master makefile.

#### Fix force clean sequence bug
If target Android API level changed from previous build, an initial clean will be triggered. However, due to the way that make expands expressions at first run, the file check for NDK toolchain config file will be also true while the file will have been deleted from triggered clean. This effectively triggers a shell cat against a missing file resulting into an ugly warning being print.

To avoid using secondary expansion, use a simple bool variable which checks if a clean has already happened before re-trying the checks against a different config.