### PR TITLE
Linux symbols filters + proc maps DSO resolve

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -274,8 +274,8 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         {{"persistent", no_argument, NULL, 'P'}, "Enable persistent fuzzing (link with libraries/persistent.c)"},
 
 #if defined(_HF_ARCH_LINUX)
-        {{"symbols_bl", required_argument, NULL, 0x504}, "Symbols blacklist filter file (one entry per line)"},
-        {{"symbols_wl", required_argument, NULL, 0x505}, "Symbols whitelist filter file (one entry per line)"},
+        {{"linux_symbols_bl", required_argument, NULL, 0x504}, "Symbols blacklist filter file (one entry per line)"},
+        {{"linux_symbols_wl", required_argument, NULL, 0x505}, "Symbols whitelist filter file (one entry per line)"},
         {{"linux_pid", required_argument, NULL, 'p'}, "Attach to a pid (and its thread group)"},
         {{"linux_file_pid", required_argument, NULL, 0x502}, "Attach to pid (and its thread group) read from file"},
         {{"linux_addr_low_limit", required_argument, NULL, 0x500}, "Address limit (from si.si_addr) below which crashes are not reported, (default: '0')"},

--- a/cmdline.c
+++ b/cmdline.c
@@ -227,6 +227,12 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
             .pid = 0,
             .pidFile = NULL,
             .pidCmd = NULL,
+            .symsBlFile = NULL,
+            .symsBlCnt = 0,
+            .symsBl = NULL,
+            .symsWlFile = NULL,
+            .symsWlCnt = 0,
+            .symsWl = NULL,
         },
     };
     /*  *INDENT-ON* */
@@ -268,6 +274,8 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         {{"persistent", no_argument, NULL, 'P'}, "Enable persistent fuzzing (link with libraries/persistent.c)"},
 
 #if defined(_HF_ARCH_LINUX)
+        {{"symbols_bl", required_argument, NULL, 0x504}, "Symbols blacklist filter file (one entry per line)"},
+        {{"symbols_wl", required_argument, NULL, 0x505}, "Symbols whitelist filter file (one entry per line)"},
         {{"linux_pid", required_argument, NULL, 'p'}, "Attach to a pid (and its thread group)"},
         {{"linux_file_pid", required_argument, NULL, 0x502}, "Attach to pid (and its thread group) read from file"},
         {{"linux_addr_low_limit", required_argument, NULL, 0x500}, "Address limit (from si.si_addr) below which crashes are not reported, (default: '0')"},
@@ -414,6 +422,12 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
             break;
         case 0x503:
             hfuzz->linux.dynamicCutOffAddr = strtoull(optarg, NULL, 0);
+            break;
+        case 0x504:
+            hfuzz->linux.symsBlFile = optarg;
+            break;
+        case 0x505:
+            hfuzz->linux.symsWlFile = optarg;
             break;
         case 0x510:
             hfuzz->dynFileMethod |= _HF_DYNFILE_INSTR_COUNT;

--- a/common.h
+++ b/common.h
@@ -279,6 +279,12 @@ typedef struct {
         pid_t pid;
         const char *pidFile;
         char *pidCmd;
+        const char *symsBlFile;
+        char **symsBl;
+        size_t symsBlCnt;
+        const char *symsWlFile;
+        char **symsWl;
+        size_t symsWlCnt;
     } linux;
 } honggfuzz_t;
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -47,13 +47,13 @@ Options:
  --help|-h
 	Help plz..
  --input|-f VALUE
-	Path to the file corpus (file or a directory)
+	Path to a directory containing initial file corpus
  --nullify_stdio|-q
 	Null-ify children's stdin, stdout, stderr; make them quiet
  --timeout|-t VALUE
 	Timeout in seconds (default: '10')
  --threads|-n VALUE
-	Number of concurrent fuzzing threads (default: '2')
+	Number of concurrent fuzzing threads (default: number of CPUs / 2)
  --stdin_input|-s
 	Provide fuzzing input on STDIN, instead of ___FILE___
  --mutation_rate|-r VALUE
@@ -71,13 +71,15 @@ Options:
  --workspace|-W VALUE
 	Workspace directory to save crashes & runtime files (default: '.')
  --covdir VALUE
-	Output directory for coverage data (default: The same as workspace directory)
+	New coverage is written to a separate directory (default: use the input directory)
  --wordlist|-w VALUE
 	Wordlist file (tokens delimited by NUL-bytes)
  --stackhash_bl|-B VALUE
 	Stackhashes blacklist file (one entry per line)
  --mutate_cmd|-c VALUE
-	External command providing fuzz files, instead of mutating the input corpus
+	External command producing fuzz files (instead of internal mutators)
+ --pprocess_cmd VALUE
+	External command postprocessing files produced by internal mutators
  --iterations|-N VALUE
 	Number of fuzzing iterations (default: '0' [no limit])
  --rlimit_as VALUE
@@ -86,41 +88,45 @@ Options:
 	Write report to this file (default: 'HONGGFUZZ.REPORT.TXT')
  --max_file_size|-F VALUE
 	Maximal size of files processed by the fuzzer in bytes (default: '1048576')
- --clear_env 
+ --clear_env
 	Clear all environment variables before executing the binary
  --env|-E VALUE
 	Pass this environment variable, can be used multiple times
- --save_all|-u 
+ --save_all|-u
 	Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames
- --sancov|-C 
+ --sancov|-C
 	Enable sanitizer coverage feedback
- --instr|-z 
-	Enable compile-time instrumentation (see libraries/instrument_func.c)
- --msan_report_umrs 
+ --instrument|-z
+	Enable compile-time instrumentation (link with libraries/instrument.a)
+ --msan_report_umrs
 	Report MSAN's UMRS (uninitialized memory access)
- --persistent|-P 
-	Enable persistent fuzzing (link with libraries/persistent.mode.main.o)
+ --persistent|-P
+	Enable persistent fuzzing (link with libraries/persistent.c)
+ --linux_symbols_bl VALUE
+	Symbols blacklist filter file (one entry per line)
+ --linux_symbols_wl VALUE
+	Symbols whitelist filter file (one entry per line)
  --linux_pid|-p VALUE
 	Attach to a pid (and its thread group)
  --linux_file_pid VALUE
 	Attach to pid (and its thread group) read from file
  --linux_addr_low_limit VALUE
 	Address limit (from si.si_addr) below which crashes are not reported, (default: '0')
- --linux_keep_aslr 
+ --linux_keep_aslr
 	Don't disable ASLR randomization, might be useful with MSAN
  --linux_perf_ignore_above VALUE
 	Ignore perf events which report IPs above this address
- --linux_perf_instr 
+ --linux_perf_instr
 	Use PERF_COUNT_HW_INSTRUCTIONS perf
- --linux_perf_branch 
+ --linux_perf_branch
 	Use PERF_COUNT_HW_BRANCH_INSTRUCTIONS perf
- --linux_perf_bts_block 
+ --linux_perf_bts_block
 	Use Intel BTS to count unique blocks
- --linux_perf_bts_edge 
+ --linux_perf_bts_edge
 	Use Intel BTS to count unique edges
- --linux_perf_ipt_block 
+ --linux_perf_ipt_block
 	Use Intel Processor Trace to count unique blocks
- --linux_perf_custom 
+ --linux_perf_custom
 	Custom counter (based on GS register for x86_64)
 
 Examples:
@@ -138,10 +144,12 @@ Examples:
   honggfuzz --linux_perf_instr -- /usr/bin/tiffinfo -D ___FILE___
  Run the binary over a dynamic file, maximize total no. of branches:
   honggfuzz --linux_perf_branch -- /usr/bin/tiffinfo -D ___FILE___
- Run the binary over a dynamic file, maximize unique code blocks (coverage):
-  honggfuzz --linux_perf_ip -- /usr/bin/tiffinfo -D ___FILE___
- Run the binary over a dynamic file, maximize unique branches (edges):
-  honggfuzz --linux_perf_ip_addr -- /usr/bin/tiffinfo -D ___FILE___
+ Run the binary over a dynamic file, maximize unique code blocks via BTS:
+  honggfuzz --linux_perf_bts_block -- /usr/bin/tiffinfo -D ___FILE___
+ Run the binary over a dynamic file, maximize unique branches (edges) via BTS:
+  honggfuzz --linux_perf_bts_edge -- /usr/bin/tiffinfo -D
+ Run the binary over a dynamic file, maximize unique code blocks via Intel Processor Trace:
+  honggfuzz --linux_perf_ipt_block -- /usr/bin/tiffinfo -D ___FILE___
  Run the binary over a dynamic file, maximize custom counters (experimental):
   honggfuzz --linux_perf_custom -- /usr/bin/tiffinfo -D ___FILE___
 ```

--- a/files.c
+++ b/files.c
@@ -430,15 +430,21 @@ bool files_parseBlacklist(honggfuzz_t * hfuzz)
     return true;
 }
 
-size_t files_parseSymbolFilter(const char *inFIle, char ***filterList)
+/*
+ * Reads symbols from src file (one per line) and append them to filterList. The
+ * total number of added symbols is returned.
+ *
+ * Simple wildcard strings are also supported (e.g. mem*)
+ */
+size_t files_parseSymbolFilter(const char *srcFile, char ***filterList)
 {
-    FILE *fSBl = fopen(inFIle, "rb");
-    if (fSBl == NULL) {
-        PLOG_W("Couldn't open '%s' - R/O mode", inFIle);
+    FILE *f = fopen(srcFile, "rb");
+    if (f == NULL) {
+        PLOG_W("Couldn't open '%s' - R/O mode", srcFile);
         return 0;
     }
     defer {
-        fclose(fSBl);
+        fclose(f);
     };
 
     char *lineptr = NULL;
@@ -448,7 +454,7 @@ size_t files_parseSymbolFilter(const char *inFIle, char ***filterList)
 
     size_t symbolsRead = 0, n = 0;
     for (;;) {
-        if (getline(&lineptr, &n, fSBl) == -1) {
+        if (getline(&lineptr, &n, f) == -1) {
             break;
         }
 

--- a/files.c
+++ b/files.c
@@ -464,16 +464,17 @@ size_t files_parseSymbolFilter(const char *srcFile, char ***filterList)
         }
 
         if ((*filterList =
-             util_Realloc(*filterList, (symbolsRead + 1) * sizeof(*filterList[0]))) == NULL) {
-            PLOG_W("realloc failed (sz=%zu)", (symbolsRead + 1) * sizeof(*filterList[0]));
+             (char **)util_Realloc(*filterList,
+                                   (symbolsRead + 1) * sizeof((*filterList)[0]))) == NULL) {
+            PLOG_W("realloc failed (sz=%zu)", (symbolsRead + 1) * sizeof((*filterList)[0]));
             return 0;
         }
-        *filterList[symbolsRead] = malloc(strlen(lineptr));
-        if (!*filterList[symbolsRead]) {
+        (*filterList)[symbolsRead] = malloc(strlen(lineptr));
+        if (!(*filterList)[symbolsRead]) {
             PLOG_E("malloc(%zu) failed", strlen(lineptr));
             return 0;
         }
-        strncpy(*filterList[symbolsRead], lineptr, strlen(lineptr));
+        strncpy((*filterList)[symbolsRead], lineptr, strlen(lineptr));
         symbolsRead++;
     }
 

--- a/files.h
+++ b/files.h
@@ -64,4 +64,6 @@ extern bool files_readPidFromFile(const char *fileName, pid_t * pidPtr);
 
 extern struct paths_t *files_getFileFromFileq(honggfuzz_t * hfuzz, size_t index);
 
+extern size_t files_parseSymbolFilter(const char *inFIle, char ***filterList);
+
 #endif

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -148,28 +148,18 @@ int main(int argc, char **argv)
     if (hfuzz.blacklistFile && (files_parseBlacklist(&hfuzz) == false)) {
         LOG_F("Couldn't parse stackhash blacklist file ('%s')", hfuzz.blacklistFile);
     }
-
-    if (hfuzz.linux.symsBlFile
-        &&
-        ((hfuzz.linux.symsBlCnt =
-          files_parseSymbolFilter(hfuzz.linux.symsBlFile, &hfuzz.linux.symsBl)) == 0)) {
-        LOG_F("Couldn't parse symbols blacklist file ('%s')", hfuzz.linux.symsBlFile);
+    /*  *INDENT-OFF* */
+    #define hfuzzl hfuzz.linux
+    if (hfuzzl.symsBlFile &&
+        ((hfuzzl.symsBlCnt = files_parseSymbolFilter(hfuzzl.symsBlFile, &hfuzzl.symsBl)) == 0)) {
+        LOG_F("Couldn't parse symbols blacklist file ('%s')", hfuzzl.symsBlFile);
     }
 
-    if (hfuzz.linux.symsWlFile
-        &&
-        ((hfuzz.linux.symsWlCnt =
-          files_parseSymbolFilter(hfuzz.linux.symsWlFile, &hfuzz.linux.symsWl)) == 0)) {
-        LOG_F("Couldn't parse symbols whitelist file ('%s')", hfuzz.linux.symsWlFile);
+    if (hfuzzl.symsWlFile &&
+        ((hfuzzl.symsWlCnt = files_parseSymbolFilter(hfuzzl.symsWlFile, &hfuzzl.symsWl)) == 0)) {
+        LOG_F("Couldn't parse symbols whitelist file ('%s')", hfuzzl.symsWlFile);
     }
-
-    if (hfuzz.dynFileMethod != _HF_DYNFILE_NONE) {
-        hfuzz.feedback = files_mapSharedMem(sizeof(feedback_t), &hfuzz.bbFd, hfuzz.workDir);
-        if (hfuzz.feedback == MAP_FAILED) {
-            LOG_F("files_mapSharedMem(sz=%zu, dir='%s') failed", sizeof(feedback_t), hfuzz.workDir);
-        }
-    }
-
+    /*  *INDENT-ON* */
     /*
      * So far so good
      */

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -149,6 +149,20 @@ int main(int argc, char **argv)
         LOG_F("Couldn't parse stackhash blacklist file ('%s')", hfuzz.blacklistFile);
     }
 
+    if (hfuzz.linux.symsBlFile
+        &&
+        ((hfuzz.linux.symsBlCnt =
+          files_parseSymbolFilter(hfuzz.linux.symsBlFile, &hfuzz.linux.symsBl)) == 0)) {
+        LOG_F("Couldn't parse symbols blacklist file ('%s')", hfuzz.linux.symsBlFile);
+    }
+
+    if (hfuzz.linux.symsWlFile
+        &&
+        ((hfuzz.linux.symsWlCnt =
+          files_parseSymbolFilter(hfuzz.linux.symsWlFile, &hfuzz.linux.symsWl)) == 0)) {
+        LOG_F("Couldn't parse symbols whitelist file ('%s')", hfuzz.linux.symsWlFile);
+    }
+
     if (hfuzz.dynFileMethod != _HF_DYNFILE_NONE) {
         hfuzz.feedback = files_mapSharedMem(sizeof(feedback_t), &hfuzz.bbFd, hfuzz.workDir);
         if (hfuzz.feedback == MAP_FAILED) {
@@ -185,6 +199,12 @@ int main(int argc, char **argv)
     /* Clean-up global buffers */
     if (hfuzz.blacklist) {
         free(hfuzz.blacklist);
+    }
+    if (hfuzz.linux.symsBl) {
+        free(hfuzz.linux.symsBl);
+    }
+    if (hfuzz.linux.symsWl) {
+        free(hfuzz.linux.symsWl);
     }
     if (hfuzz.sanOpts.asanOpts) {
         free(hfuzz.sanOpts.asanOpts);

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -148,8 +148,7 @@ int main(int argc, char **argv)
     if (hfuzz.blacklistFile && (files_parseBlacklist(&hfuzz) == false)) {
         LOG_F("Couldn't parse stackhash blacklist file ('%s')", hfuzz.blacklistFile);
     }
-    /*  *INDENT-OFF* */
-    #define hfuzzl hfuzz.linux
+#define hfuzzl hfuzz.linux
     if (hfuzzl.symsBlFile &&
         ((hfuzzl.symsBlCnt = files_parseSymbolFilter(hfuzzl.symsBlFile, &hfuzzl.symsBl)) == 0)) {
         LOG_F("Couldn't parse symbols blacklist file ('%s')", hfuzzl.symsBlFile);
@@ -159,7 +158,7 @@ int main(int argc, char **argv)
         ((hfuzzl.symsWlCnt = files_parseSymbolFilter(hfuzzl.symsWlFile, &hfuzzl.symsWl)) == 0)) {
         LOG_F("Couldn't parse symbols whitelist file ('%s')", hfuzzl.symsWlFile);
     }
-    /*  *INDENT-ON* */
+
     /*
      * So far so good
      */

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -637,8 +637,9 @@ arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs, size_t 
         else
             util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[]\n");
 #else
-        util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> [%s():%u at %s]\n",
-                       (REG_TYPE) (long)funcs[i].pc, funcs[i].func, funcs[i].line, funcs[i].mapName);
+        util_ssnprintf(fuzzer->report, sizeof(fuzzer->report),
+                       " <" REG_PD REG_PM "> [%s():%u at %s]\n", (REG_TYPE) (long)funcs[i].pc,
+                       funcs[i].func, funcs[i].line, funcs[i].mapName);
 #endif
     }
 
@@ -1000,7 +1001,8 @@ static int arch_parseAsanReport(honggfuzz_t * hfuzz, pid_t pid, funcs_t * funcs,
                 if ((startOff == NULL) || (endOff == NULL) || (plusOff == NULL)) {
                     LOG_D("Invalid ASan report entry (%s)", lineptr);
                 } else {
-                    size_t dsoSz = MIN(sizeof(funcs[frameIdx].mapName), (size_t) (plusOff - startOff));
+                    size_t dsoSz =
+                        MIN(sizeof(funcs[frameIdx].mapName), (size_t) (plusOff - startOff));
                     memcpy(funcs[frameIdx].mapName, startOff, dsoSz);
                     char *codeOff = targetStr + (plusOff - startOff) + 1;
                     funcs[frameIdx].line = strtoull(codeOff, NULL, 16);

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -630,7 +630,7 @@ arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs, size_t 
     for (size_t i = 0; i < funcCnt; i++) {
 #ifdef __HF_USE_CAPSTONE__
         util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> ",
-                       (REG_TYPE) (long)funcs[i].pc, funcs[i].func, funcs[i].line);
+                       (REG_TYPE) (long)funcs[i].pc);
         if (funcs[i].func[0] != '\0')
             util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s + 0x%x]\n",
                            funcs[i].func, funcs[i].line);
@@ -1199,7 +1199,7 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
         util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "STACK:\n");
         for (int i = 0; i < funcCnt; i++) {
             util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> ",
-                           (REG_TYPE) (long)funcs[i].pc, funcs[i].func, funcs[i].line);
+                           (REG_TYPE) (long)funcs[i].pc);
             if (funcs[i].func[0] != '\0') {
                 util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s + 0x%x]\n",
                                funcs[i].func, funcs[i].line);

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -1000,8 +1000,8 @@ static int arch_parseAsanReport(honggfuzz_t * hfuzz, pid_t pid, funcs_t * funcs,
                 if ((startOff == NULL) || (endOff == NULL) || (plusOff == NULL)) {
                     LOG_D("Invalid ASan report entry (%s)", lineptr);
                 } else {
-                    size_t dsoSz = MIN(sizeof(funcs[frameIdx].func), (size_t) (plusOff - startOff));
-                    memcpy(funcs[frameIdx].func, startOff, dsoSz);
+                    size_t dsoSz = MIN(sizeof(funcs[frameIdx].mapName), (size_t) (plusOff - startOff));
+                    memcpy(funcs[frameIdx].mapName, startOff, dsoSz);
                     char *codeOff = targetStr + (plusOff - startOff) + 1;
                     funcs[frameIdx].line = strtoull(codeOff, NULL, 16);
                 }
@@ -1190,9 +1190,9 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
         for (int i = 0; i < funcCnt; i++) {
             util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> ",
                            (REG_TYPE) (long)funcs[i].pc);
-            if (funcs[i].func[0] != '\0') {
+            if (funcs[i].mapName[0] != '\0') {
                 util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s + 0x%x]\n",
-                               funcs[i].func, funcs[i].line);
+                               funcs[i].mapName, funcs[i].line);
             } else {
                 util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[]\n");
             }

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -632,8 +632,8 @@ arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs, size_t 
         util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> ",
                        (REG_TYPE) (long)funcs[i].pc);
         if (funcs[i].func[0] != '\0')
-            util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s:%s() + 0x%x]\n",
-                           funcs[i].mapName, funcs[i].func, funcs[i].line);
+            util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s() + 0x%x at %s]\n",
+                           funcs[i].func, funcs[i].line, funcs[i].mapName);
         else
             util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[]\n");
 #else

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -665,14 +665,11 @@ static void arch_ptraceAnalyzeData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fu
     /*
      * Unwind and resolve symbols
      */
-    /*  *INDENT-OFF* */
-    funcs_t funcs[_HF_MAX_FUNCS] = {
-        [0 ... (_HF_MAX_FUNCS - 1)].pc = NULL,
-        [0 ... (_HF_MAX_FUNCS - 1)].line = 0,
-        [0 ... (_HF_MAX_FUNCS - 1)].func = {'\0'}
-        ,
-    };
-    /*  *INDENT-ON* */
+    funcs_t *funcs = util_Malloc(_HF_MAX_FUNCS * sizeof(funcs_t));
+    defer {
+        free(funcs);
+    }
+    memset(funcs, 0, _HF_MAX_FUNCS * sizeof(funcs_t));
 
 #if !defined(__ANDROID__)
     size_t funcCnt = arch_unwindStack(pid, funcs);
@@ -730,14 +727,11 @@ static void arch_ptraceSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzze
     /*
      * Unwind and resolve symbols
      */
-    /*  *INDENT-OFF* */
-    funcs_t funcs[_HF_MAX_FUNCS] = {
-        [0 ... (_HF_MAX_FUNCS - 1)].pc = NULL,
-        [0 ... (_HF_MAX_FUNCS - 1)].line = 0,
-        [0 ... (_HF_MAX_FUNCS - 1)].func = {'\0'}
-        ,
-    };
-    /*  *INDENT-ON* */
+    funcs_t *funcs = util_Malloc(_HF_MAX_FUNCS * sizeof(funcs_t));
+    defer {
+        free(funcs);
+    }
+    memset(funcs, 0, _HF_MAX_FUNCS * sizeof(funcs_t));
 
 #if !defined(__ANDROID__)
     size_t funcCnt = arch_unwindStack(pid, funcs);
@@ -1058,15 +1052,11 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
 
     /* If sanitizer produces reports with stack traces (e.g. ASan), they're parsed manually */
     int funcCnt = 0;
-
-    /*  *INDENT-OFF* */
-    funcs_t funcs[_HF_MAX_FUNCS] = {
-        [0 ... (_HF_MAX_FUNCS - 1)].pc = NULL,
-        [0 ... (_HF_MAX_FUNCS - 1)].line = 0,
-        [0 ... (_HF_MAX_FUNCS - 1)].func = {'\0'}
-        ,
-    };
-    /*  *INDENT-ON* */
+    funcs_t *funcs = util_Malloc(_HF_MAX_FUNCS * sizeof(funcs_t));
+    defer {
+        free(funcs);
+    }
+    memset(funcs, 0, _HF_MAX_FUNCS * sizeof(funcs_t));
 
     /* If ASan crash, parse report */
     if (exitCode == HF_ASAN_EXIT_CODE) {
@@ -1221,15 +1211,11 @@ static void arch_ptraceExitAnalyzeData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t 
     void *crashAddr = 0;
     char *op = "UNKNOWN";
     int funcCnt = 0;
-
-    /*  *INDENT-OFF* */
-    funcs_t funcs[_HF_MAX_FUNCS] = {
-        [0 ... (_HF_MAX_FUNCS - 1)].pc = NULL,
-        [0 ... (_HF_MAX_FUNCS - 1)].line = 0,
-        [0 ... (_HF_MAX_FUNCS - 1)].func = {'\0'}
-        ,
-    };
-    /*  *INDENT-ON* */
+    funcs_t *funcs = util_Malloc(_HF_MAX_FUNCS * sizeof(funcs_t));
+    defer {
+        free(funcs);
+    }
+    memset(funcs, 0, _HF_MAX_FUNCS * sizeof(funcs_t));
 
     funcCnt = arch_parseAsanReport(hfuzz, pid, funcs, &crashAddr, &op);
 

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -632,13 +632,13 @@ arch_ptraceGenerateReport(pid_t pid, fuzzer_t * fuzzer, funcs_t * funcs, size_t 
         util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> ",
                        (REG_TYPE) (long)funcs[i].pc);
         if (funcs[i].func[0] != '\0')
-            util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s + 0x%x]\n",
-                           funcs[i].func, funcs[i].line);
+            util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[%s:%s() + 0x%x]\n",
+                           funcs[i].mapName, funcs[i].func, funcs[i].line);
         else
             util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "[]\n");
 #else
-        util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> [%s():%u]\n",
-                       (REG_TYPE) (long)funcs[i].pc, funcs[i].func, funcs[i].line);
+        util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), " <" REG_PD REG_PM "> [%s():%u at %s]\n",
+                       (REG_TYPE) (long)funcs[i].pc, funcs[i].func, funcs[i].line, funcs[i].mapName);
 #endif
     }
 

--- a/linux/unwind.c
+++ b/linux/unwind.c
@@ -24,6 +24,9 @@
 #include "../common.h"
 #include "unwind.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <endian.h>
 #include <libunwind-ptrace.h>
 
@@ -49,10 +52,82 @@ static const char *UNW_ER[] = {
     "UNW_ENOINFO"               /* no unwind info found */
 };
 
+typedef struct {
+    unsigned long start;
+    unsigned long end;
+    char perms[6];
+    unsigned long offset;
+    char dev[8];
+    unsigned long inode;
+    char name[PATH_MAX];
+} procMap_t;
+
+static procMap_t *arch_parsePidMaps(pid_t pid, size_t * mapsCount)
+{
+    FILE *f = NULL;
+    char fProcMaps[PATH_MAX] = { 0 };
+    snprintf(fProcMaps, PATH_MAX, "/proc/%d/maps", pid);
+
+    if ((f = fopen(fProcMaps, "rb")) == NULL) {
+        PLOG_E("Couldn't open '%s' - R/O mode", fProcMaps);
+        return 0;
+    }
+    defer {
+        fclose(f);
+    };
+
+    *mapsCount = 0;
+    procMap_t *mapsList = malloc(sizeof(procMap_t));
+    if (mapsList == NULL) {
+        PLOG_W("malloc(size='%zu')", sizeof(procMap_t));
+        return NULL;
+    }
+
+    while (!feof(f)) {
+        char buf[sizeof(procMap_t) + 1];
+        if (fgets(buf, sizeof(buf), f) == 0) {
+            break;
+        }
+
+        mapsList[*mapsCount].name[0] = '\0';
+        sscanf(buf, "%lx-%lx %5s %lx %7s %ld %s", &mapsList[*mapsCount].start,
+               &mapsList[*mapsCount].end, mapsList[*mapsCount].perms, &mapsList[*mapsCount].offset,
+               mapsList[*mapsCount].dev, &mapsList[*mapsCount].inode, mapsList[*mapsCount].name);
+
+        *mapsCount += 1;
+        if ((mapsList = realloc(mapsList, (*mapsCount + 1) * sizeof(procMap_t))) == NULL) {
+            PLOG_W("realloc failed (sz=%zu)", (*mapsCount + 1) * sizeof(procMap_t));
+            free(mapsList);
+            return NULL;
+        }
+    }
+
+    return mapsList;
+}
+
+static char *arch_searchMaps(unsigned long addr, size_t mapsCnt, procMap_t * mapsList)
+{
+    for (size_t i = 0; i < mapsCnt; i++) {
+        if (addr >= mapsList[i].start && addr <= mapsList[i].end) {
+            return mapsList[i].name;
+        }
+
+        /* Benefit from maps being sorted by address */
+        if (addr < mapsList[i].start) {
+            break;
+        }
+    }
+    return NULL;
+}
+
 #ifndef __ANDROID__
 size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
 {
-    size_t num_frames = 0;
+    size_t num_frames = 0, mapsCnt = 0;
+    procMap_t *mapsList = arch_parsePidMaps(pid, &mapsCnt);
+    defer {
+        free(mapsList);
+    }
 
     unw_addr_space_t as = unw_create_addr_space(&_UPT_accessors, __BYTE_ORDER);
     if (!as) {
@@ -81,12 +156,19 @@ size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
 
     for (num_frames = 0; unw_step(&c) > 0 && num_frames < _HF_MAX_FUNCS; num_frames++) {
         unw_word_t ip;
+        char *mapName = NULL;
         ret = unw_get_reg(&c, UNW_REG_IP, &ip);
         if (ret < 0) {
             LOG_E("[pid='%d'] [%zd] failed to read IP (%s)", pid, num_frames, UNW_ER[-ret]);
             funcs[num_frames].pc = 0;
-        } else
+        } else {
             funcs[num_frames].pc = (void *)ip;
+        }
+        if (mapsCnt > 0 && (mapName = arch_searchMaps(ip, mapsCnt, mapsList)) != NULL) {
+            memcpy(funcs[num_frames].mapName, mapName, sizeof(funcs[num_frames].mapName));
+        } else {
+            strncpy(funcs[num_frames].mapName, "UNKNOWN", sizeof(funcs[num_frames].mapName));
+        }
     }
 
     return num_frames;
@@ -95,7 +177,12 @@ size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
 #else                           /* !defined(__ANDROID__) */
 size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
 {
-    size_t num_frames = 0;
+    size_t num_frames = 0, mapsCnt = 0;
+    procMap_t *mapsList = arch_parsePidMaps(pid, &mapsCnt);
+    defer {
+        free(mapsList);
+    }
+
     unw_addr_space_t as = unw_create_addr_space(&_UPT_accessors, __BYTE_ORDER);
     if (!as) {
         LOG_E("[pid='%d'] unw_create_addr_space failed", pid);
@@ -122,6 +209,7 @@ size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
     }
 
     do {
+        char *mapName = NULL;
         unw_word_t pc = 0, offset = 0;
         char buf[_HF_FUNC_NAME_SZ] = { 0 };
 
@@ -154,6 +242,11 @@ size_t arch_unwindStack(pid_t pid, funcs_t * funcs)
         funcs[num_frames].line = offset;
         funcs[num_frames].pc = (void *)pc;
         memcpy(funcs[num_frames].func, buf, sizeof(funcs[num_frames].func));
+        if (mapsCnt > 0 && (mapName = arch_searchMaps(pc, mapsCnt, mapsList)) != NULL) {
+            memcpy(funcs[num_frames].mapName, mapName, sizeof(funcs[num_frames].mapName));
+        } else {
+            strncpy(funcs[num_frames].mapName, "UNKNOWN", sizeof(funcs[num_frames].mapName));
+        }
 
         num_frames++;
 

--- a/linux/unwind.h
+++ b/linux/unwind.h
@@ -30,7 +30,21 @@
 #define _HF_MAX_FUNCS 80
 typedef struct {
     void *pc;
+
+    /* If ASan custom parsing, function not available without symbolication */
     char func[_HF_FUNC_NAME_SZ];
+
+    /*
+     * If libuwind proc maps is used to retrieve map name
+     * If ASan custom parsing it's retrieved from generated report file
+     */
+    char mapName[PATH_MAX];
+
+    /*
+     * If libunwind + bfd symbolizer, line is actual symbol file line
+     * If libunwind + custom (e.g. Android), line is offset from function symbol
+     * If ASan custom parsing, line is offset from matching map load base address
+     */
     size_t line;
 } funcs_t;
 

--- a/linux/unwind.h
+++ b/linux/unwind.h
@@ -35,5 +35,7 @@ typedef struct {
 } funcs_t;
 
 extern size_t arch_unwindStack(pid_t pid, funcs_t * funcs);
+extern char *arch_btContainsSymbol(size_t symbolsListSz, char **symbolsList, size_t num_frames,
+                                   funcs_t * funcs);
 
 #endif


### PR DESCRIPTION
#### Symbol filters
For some of my use cases with jemalloc under Android I want to treat all crashes as unique when top frames contain symbols from allocator functions. The stackhash approach is most of the times good enough, although not always, resulting into few crashes being missed (specially in Android due to bionic many function proxy layers).

To cover this case (+blacklist per symbol when stackhash is not enough due to type of corruption e.g. function pointer) the concept of symbol filters (blacklist/whitelist) is implemented.

User can set filters with `--linux_symbols_bl` or `--linux_symbols_wl` options which expect an input file with one symbol per line. Simple wildcard (end of string only) case is also supported (e.g. files_*).

When whitelisted symbol is detected it has priority over both stackhash blacklist & symbol blacklist filters. When blacklisted symbol is detected the global blacklist crashes counter is also increased.

For now this featue is only enabled for Linux since for macOS the stack traces info is obtained from a single char buffer passed from crash wrangler. If such feature is desired a manual string parsing walkthrough needs to happen against the `g_fuzzer_crash_callstack` buffer.

#### proc maps DSO resolve
Utilize proc maps to extract the matching map path and include it at report stack traces. When crash is detected from an interesting signal (not ASan report parsing post exit), target pid proc maps is parsed once when unwinder is initialized and saved in a local list (heap). Then list is iterated from every resolved frame to extract the matching map name based on frame's ip address. The fact that proc map is sorted helps speeding-up search since we can early abort when matching map not found.

#### generic changes
* funcs_t array is now stored in heap instead of stack since there was a considerable size overhead when the map name (PATH_MAX * max_number_of_frames) attribute has been added to the struct.
* Update usage doc to include new cmd args
* Comments around how funcs_t frame data is utilized for all supported unwind cases.