### PR TITLE
linux/perf.c: fix --linux_perf_bts_block startup case

### DIFF
--- a/linux/perf.c
+++ b/linux/perf.c
@@ -215,7 +215,8 @@ static bool arch_perfOpen(honggfuzz_t * hfuzz, fuzzer_t * fuzzer UNUSED, pid_t p
     pem->aux_offset = pem->data_offset + pem->data_size;
     pem->aux_size = _HF_PERF_AUX_SZ;
     fuzzer->linux.perfMmapAux =
-        mmap(NULL, pem->aux_size, PROT_READ, MAP_SHARED, *perfFd, pem->aux_offset);
+        mmap(NULL, pem->aux_size, PROT_READ | PROT_WRITE, MAP_SHARED, *perfFd, pem->aux_offset);
+
     if (fuzzer->linux.perfMmapAux == MAP_FAILED) {
         munmap(fuzzer->linux.perfMmapBuf, _HF_PERF_MAP_SZ + getpagesize());
         fuzzer->linux.perfMmapBuf = NULL;


### PR DESCRIPTION
The failure:
$ honggfuzz -f in/ --linux_perf_bts_block -- /usr/bin/tiff -D ___FILE___
  [2016-11-11T23:11:20+0000][W][5951] arch_perfOpen():223 mmap(mmapAuxBuf) failed,
    try increasing the kernel.perf_event_mlock_kb sysctl (up to even 300000000): Cannot allocate memory
  [2016-11-11T23:11:20+0000][E][5951] arch_perfEnable():261 Cannot set up perf for PID=5953 (_HF_DYNFILE_BTS_BLOCK)
  [2016-11-11T23:11:20+0000][F][5951] arch_prepareChild():248 Couldn't enable perf counters for pid 5953

It seems aux data also needs WRITE permissions.

At least this change fixes startup for me.

Reported-by: Mateusz Lenik
Signed-off-by: Sergei Trofimovich <siarheit@google.com>