### PR TITLE
[android] Fix wrong linking with libhfuzz.a from main tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ android:
 
 	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./android/Android.mk \
     APP_PLATFORM=$(ANDROID_API) APP_ABI=$(ANDROID_APP_ABI) \
-    NDK_TOOLCHAIN=$(ANDROID_NDK_TOOLCHAIN) $(NDK_BUILD_ARGS)
+    NDK_TOOLCHAIN=$(ANDROID_NDK_TOOLCHAIN) $(NDK_BUILD_ARGS) \
+    APP_MODULES='honggfuzz hfuzz'
 
 # Loop all ABIs and pass-through flags since visibility is lost due to sub-process
 .PHONY: android-all

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -155,7 +155,6 @@ LOCAL_MODULE := honggfuzz
 LOCAL_SRC_FILES := $(wildcard *.c)
 LOCAL_CFLAGS := $(COMMON_CFLAGS)
 LOCAL_LDFLAGS := -lm -latomic
-LOCAL_STATIC_LIBRARIES := libhfuzz
 
 ifeq ($(ANDROID_WITH_PTRACE),true)
   LOCAL_C_INCLUDES := third_party/android/libunwind/include \


### PR DESCRIPTION
libhfuzz is not an actual dependency of the honggfuzz standalone tool. Instead it
is simply desired to always build it with the build config matching the main tool so
that it is available to user for wrapping targets with instrumentation.

Having libhfuzz as part of LOCAL_STATIC_LIBRARIES effectively instructs NDK
automation to include it as dependency. This results into resolving some of the
external libc dependencies (strcmp, strstr, etc.) with the ones implemented from
libhfuzz. This is not desired since it breaks functionality.

Replace LOCAL_STATIC_LIBRARIES dependency with a proper APP_MODULES
list when invoking ndk-build to always build both modules.