### PR TITLE
Fix broken docs links

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 
 <p><strong>Description</strong></p>
 
-<p>A security oriented, feedback-driven, evolutionary, easy-to-use fuzzer with interesting analysis options. See <a href="docs/USAGE.md">USAGE</a> for details</p>
+<p>A security oriented, feedback-driven, evolutionary, easy-to-use fuzzer with interesting analysis options. See <a href="https://github.com/google/honggfuzz/blob/master/docs/USAGE.md">USAGE</a> for details</p>
 
 <ul>
 <li>Supports several hardware-based (CPU) and software-based <a href="https://github.com/google/honggfuzz/blob/master/docs/FeedbackDrivenFuzzing.md">feedback-driven fuzzing</a> methods</li>
@@ -64,7 +64,7 @@
 <li>
 <strong>FreeBSD</strong> - gmake</li>
 <li>
-<strong>Android</strong> - Android SDK/NDK. Also see <a href="docs/Android.md">this detailed doc</a> on how to build and run it</li>
+<strong>Android</strong> - Android SDK/NDK. Also see <a href="https://github.com/google/honggfuzz/blob/master/docs/Android.md">this detailed doc</a> on how to build and run it</li>
 <li>
 <strong>Windows</strong> - CygWin</li>
 <li>


### PR DESCRIPTION
These two links are broken because they're relative; this makes them consistent with the rest of the html page.