### PR TITLE
Refactor sanitizers env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ LD = $(CC)
 BIN := honggfuzz
 COMMON_CFLAGS := -D_GNU_SOURCE -Wall -Werror -Wframe-larger-than=131072
 COMMON_LDFLAGS := -lm
-COMMON_SRCS := honggfuzz.c cmdline.c display.c files.c fuzz.c log.c mangle.c report.c sancov.c subproc.c util.c
+COMMON_SRCS := $(wildcard *.c)
 CFLAGS ?= -O3
 LDFLAGS ?=
 

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -15,6 +15,9 @@
 
 LOCAL_PATH := $(abspath $(call my-dir)/..)
 
+# Maintain a local copy since some NDK versions lose LOCAL_PATH scope at POST_BUILD_EVENT
+MY_LOCAL_PATH := $(LOCAL_PATH)
+
 # Force a clean if target API has changed and a previous build exists
 CLEAN_RUN := false
 ifneq ("$(wildcard $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt)","")
@@ -186,8 +189,8 @@ include $(BUILD_EXECUTABLE)
 # required.
 all:POST_BUILD_EVENT
 POST_BUILD_EVENT:
-	@echo $(APP_PLATFORM) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt
-	@echo $(NDK_TOOLCHAIN) > $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt
-	@test -f $(LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a && \
-	  cp $(LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a \
-	    $(LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/libhfuzz.a || true
+	@echo $(APP_PLATFORM) > $(MY_LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/android_api.txt
+	@echo $(NDK_TOOLCHAIN) > $(MY_LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/ndk_toolchain.txt
+	@test -f $(MY_LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a && \
+	  cp $(MY_LOCAL_PATH)/obj/local/$(TARGET_ARCH_ABI)/libhfuzz.a \
+	    $(MY_LOCAL_PATH)/libs/$(TARGET_ARCH_ABI)/libhfuzz.a || true

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -36,22 +36,22 @@ ifeq ($(CLEAN_RUN),false)
   endif
 endif
 
+ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi armeabi-v7a))
+  ARCH_ABI := arm
+else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86))
+  ARCH_ABI := x86
+else ifeq ($(APP_ABI),$(filter $(APP_ABI),arm64-v8a))
+  ARCH_ABI := arm64
+else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86_64))
+  ARCH_ABI := x86_64
+else
+  $(error Unsuported / Unknown APP_API '$(APP_ABI)')
+endif
+
 # Enable Linux ptrace() instead of POSIX signal interface by default
 ANDROID_WITH_PTRACE ?= true
 
 ifeq ($(ANDROID_WITH_PTRACE),true)
-  ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi armeabi-v7a))
-    ARCH_ABI := arm
-  else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86))
-    ARCH_ABI := x86
-  else ifeq ($(APP_ABI),$(filter $(APP_ABI),arm64-v8a))
-    ARCH_ABI := arm64
-  else ifeq ($(APP_ABI),$(filter $(APP_ABI),x86_64))
-    ARCH_ABI := x86_64
-  else
-    $(error Unsuported / Unknown APP_API '$(APP_ABI)')
-  endif
-
   # Additional libcrypto OpenSSL flags required to mitigate bug (ARM systems with API <= 21)
   ifeq ($(APP_ABI),$(filter $(APP_ABI),armeabi))
     OPENSSL_ARMCAP_ABI := "5"

--- a/cmdline.c
+++ b/cmdline.c
@@ -526,8 +526,7 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
           cmdlineYesNo(hfuzz->saveUnique), hfuzz->origFlipRate,
           hfuzz->externalCommand == NULL ? "NULL" : hfuzz->externalCommand, hfuzz->tmOut,
           hfuzz->mutationsMax, hfuzz->threadsMax, hfuzz->fileExtn,
-          hfuzz->asLimit, hfuzz->cmdline[0], hfuzz->linux.pid,
-          cmdlineYesNo(hfuzz->monitorSIGABRT));
+          hfuzz->asLimit, hfuzz->cmdline[0], hfuzz->linux.pid, cmdlineYesNo(hfuzz->monitorSIGABRT));
 
     snprintf(hfuzz->cmdline_txt, sizeof(hfuzz->cmdline_txt), "%s", hfuzz->cmdline[0]);
     for (size_t i = 1; hfuzz->cmdline[i]; i++) {

--- a/cmdline.c
+++ b/cmdline.c
@@ -518,6 +518,15 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
         LOG_I("Verifier enabled with 0.0 flipRate, activating dry run mode");
     }
 
+    /*
+     * 'enableSanitizers' can be auto enabled when 'useSanCov', although it's probably
+     * better to let user know about the features that each flag control.
+     */
+    if (hfuzz->useSanCov == true && hfuzz->enableSanitizers == false) {
+        LOG_E("Sanitizer coverage cannot be used without enabling sanitizers '-S/--sanitizers'");
+        return false;
+    }
+
     LOG_I("inputDir '%s', nullifyStdio: %s, fuzzStdin: %s, saveUnique: %s, flipRate: %lf, "
           "externalCommand: '%s', tmOut: %ld, mutationsMax: %zu, threadsMax: %zu, fileExtn: '%s', "
           "memoryLimit: 0x%" PRIx64 "(MiB), fuzzExe: '%s', fuzzedPid: %d, monitorSIGABRT: '%s'",

--- a/cmdline.c
+++ b/cmdline.c
@@ -519,14 +519,15 @@ bool cmdlineParse(int argc, char *argv[], honggfuzz_t * hfuzz)
     }
 
     LOG_I("inputDir '%s', nullifyStdio: %s, fuzzStdin: %s, saveUnique: %s, flipRate: %lf, "
-          "externalCommand: '%s', tmOut: %ld, mutationsMax: %zu, threadsMax: %zu, fileExtn '%s', "
-          "memoryLimit: 0x%" PRIx64 "(MiB), fuzzExe: '%s', fuzzedPid: %d",
+          "externalCommand: '%s', tmOut: %ld, mutationsMax: %zu, threadsMax: %zu, fileExtn: '%s', "
+          "memoryLimit: 0x%" PRIx64 "(MiB), fuzzExe: '%s', fuzzedPid: %d, monitorSIGABRT: '%s'",
           hfuzz->inputDir,
           cmdlineYesNo(hfuzz->nullifyStdio), cmdlineYesNo(hfuzz->fuzzStdin),
           cmdlineYesNo(hfuzz->saveUnique), hfuzz->origFlipRate,
           hfuzz->externalCommand == NULL ? "NULL" : hfuzz->externalCommand, hfuzz->tmOut,
           hfuzz->mutationsMax, hfuzz->threadsMax, hfuzz->fileExtn,
-          hfuzz->asLimit, hfuzz->cmdline[0], hfuzz->linux.pid);
+          hfuzz->asLimit, hfuzz->cmdline[0], hfuzz->linux.pid,
+          cmdlineYesNo(hfuzz->monitorSIGABRT));
 
     snprintf(hfuzz->cmdline_txt, sizeof(hfuzz->cmdline_txt), "%s", hfuzz->cmdline[0]);
     for (size_t i = 1; hfuzz->cmdline[i]; i++) {

--- a/common.h
+++ b/common.h
@@ -85,12 +85,6 @@ static void __attribute__ ((unused)) __clang_cleanup_func(void (^*dfunc) (void))
 /* Maximum number of PC guards (=trace-pc-guard) we support */
 #define _HF_PC_GUARD_MAX (1024U * 1024U)
 
-#if defined(__ANDROID__)
-#define _HF_MONITOR_SIGABRT 0
-#else
-#define _HF_MONITOR_SIGABRT 1
-#endif
-
 #define ARRAYSIZE(x) (sizeof(x) / sizeof(*x))
 
 /* Memory barriers */
@@ -238,6 +232,8 @@ typedef struct {
     char *envs[128];
     bool persistent;
     bool tmout_vtalrm;
+    bool enableSanitizers;
+    bool monitorSIGABRT;
 
     const char *dictionaryFile;
      TAILQ_HEAD(, strings_t) dictq;

--- a/fuzz.c
+++ b/fuzz.c
@@ -48,6 +48,7 @@
 #include "log.h"
 #include "mangle.h"
 #include "report.h"
+#include "sanitizers.h"
 #include "sancov.h"
 #include "subproc.h"
 #include "util.h"
@@ -616,6 +617,9 @@ void fuzz_threads(honggfuzz_t * hfuzz)
 
     if (!arch_archInit(hfuzz)) {
         LOG_F("Couldn't prepare arch for fuzzing");
+    }
+    if (!sanitizers_Init(hfuzz)) {
+        LOG_F("Couldn't prepare sanitizer options");
     }
     if (!sancov_Init(hfuzz)) {
         LOG_F("Couldn't prepare sancov options");

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -60,13 +60,6 @@
 #include "perf.h"
 #include "ptrace_utils.h"
 
-/* Common sanitizer flags */
-#if _HF_MONITOR_SIGABRT
-#define ABORT_FLAG        "abort_on_error=1"
-#else
-#define ABORT_FLAG        "abort_on_error=0"
-#endif
-
 /* Size of remote pid cmdline char buffer */
 #define _HF_PROC_CMDLINE_SZ 8192
 
@@ -324,26 +317,30 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
         arch_ptraceAnalyze(hfuzz, status, pid, fuzzer);
     }
 
-#if !_HF_MONITOR_SIGABRT
-    /*
-     * There might be cases where ASan instrumented targets crash while generating
-     * reports for detected errors (inside __asan_report_error() proc). Under such
-     * scenarios target fails to exit or SIGABRT (AsanDie() proc) as defined in
-     * ASAN_OPTIONS flags, leaving garbage logs. An attempt is made to parse such
-     * logs for cases where enough data are written to identify potentially missed
-     * crashes. If ASan internal error results into a SIGSEGV being raised, it
-     * will get caught from ptrace API, handling the discovered ASan internal crash.
-     */
-    char crashReport[PATH_MAX] = { 0 };
-    snprintf(crashReport, sizeof(crashReport), "%s/%s.%d", hfuzz->workDir, kLOGPREFIX, ptracePid);
-    if (files_exists(crashReport)) {
-        LOG_W("Un-handled ASan report due to compiler-rt internal error - retry with '%s' (%s)",
-              crashReport, fuzzer->fileName);
+    if (hfuzz->enableSanitizers) {
+        /*
+         * There might be cases where ASan instrumented targets crash while generating
+         * reports for detected errors (inside __asan_report_error() proc). Under such
+         * scenarios target fails to exit or SIGABRT (AsanDie() proc) as defined in
+         * ASAN_OPTIONS flags, leaving garbage logs. An attempt is made to parse such
+         * logs for cases where enough data are written to identify potentially missed
+         * crashes. If ASan internal error results into a SIGSEGV being raised, it
+         * will get caught from ptrace API, handling the discovered ASan internal crash.
+         */
+        char crashReport[PATH_MAX] = { 0 };
+        snprintf(crashReport, sizeof(crashReport), "%s/%s.%d", hfuzz->workDir, kLOGPREFIX,
+                 ptracePid);
+        if (files_exists(crashReport)) {
+            LOG_W("Un-handled ASan report due to compiler-rt internal error - retry with '%s' (%s)",
+                  crashReport, fuzzer->fileName);
 
-        /* Manually set the exitcode to ASan to trigger report parsing */
-        arch_ptraceExitAnalyze(hfuzz, ptracePid, fuzzer, HF_ASAN_EXIT_CODE);
+            /*
+             * Manually set the exitcode to ASan to trigger report parsing  since it's
+             * the only report format supported yet
+             */
+            arch_ptraceExitAnalyze(hfuzz, ptracePid, fuzzer, HF_ASAN_EXIT_CODE);
+        }
     }
-#endif
 
     arch_perfAnalyze(hfuzz, fuzzer);
     sancov_Analyze(hfuzz, fuzzer);
@@ -453,12 +450,12 @@ bool arch_archInit(honggfuzz_t * hfuzz)
     }
 
     /*
-     * If sanitizer fuzzing enabled increase number of major frames, since top 7-9 frames
+     * If sanitizer fuzzing enabled increase number of major frames, since top 5-7 frames
      * will be occupied with sanitizer symbols if 'abort_on_error' flag is set
      */
-#if _HF_MONITOR_SIGABRT
-    hfuzz->linux.numMajorFrames = 14;
-#endif
+    if (hfuzz->monitorSIGABRT) {
+        hfuzz->linux.numMajorFrames = 14;
+    }
 
     return true;
 }

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -446,8 +446,9 @@ bool arch_archInit(honggfuzz_t * hfuzz)
     }
 
     /*
-     * If sanitizer fuzzing enabled increase number of major frames, since top 5-7 frames
-     * will be occupied with sanitizer symbols if 'abort_on_error' flag is set
+     * If sanitizer fuzzing enabled increase number of major frames, since top
+     * 7-9 frames will be occupied with sanitizer symbols if 'abort_on_error'
+     * flag is set
      */
     if (hfuzz->monitorSIGABRT) {
         hfuzz->linux.numMajorFrames = 14;

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -375,10 +375,7 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
                     ("Un-handled ASan report due to compiler-rt internal error - retry with '%s' (%s)",
                      crashReport, fuzzer->fileName);
 
-                /*
-                 * Manually set the exitcode to ASan to trigger report parsing  since it's
-                 * the only report format supported yet
-                 */
+                /* Try to parse report file */
                 arch_ptraceExitAnalyze(hfuzz, ptracePid, fuzzer);
             }
         }

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -445,6 +445,9 @@ bool arch_archInit(honggfuzz_t * hfuzz)
         hfuzz->linux.pidCmd[sz] = '\0';
     }
 
+    /* Updates the important signal array based on input args */
+    arch_ptraceSignalsInit(hfuzz);
+
     /*
      * If sanitizer fuzzing enabled and SIGABRT is monitored (abort_on_error=1),
      * increase number of major frames, since top 7-9 frames will be occupied

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -325,15 +325,16 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
             if (fuzzer->backtrace) {
                 unlink(crashReport);
             } else {
-                LOG_W("Un-handled ASan report due to compiler-rt internal error - retry with '%s' (%s)",
-                      crashReport, fuzzer->fileName);
+                LOG_W
+                    ("Un-handled ASan report due to compiler-rt internal error - retry with '%s' (%s)",
+                     crashReport, fuzzer->fileName);
 
                 /*
                  * Manually set the exitcode to ASan to trigger report parsing  since it's
                  * the only report format supported yet
                  */
-                arch_ptraceExitAnalyze(hfuzz, ptracePid, fuzzer, HF_ASAN_EXIT_CODE);
-                }
+                arch_ptraceExitAnalyze(hfuzz, ptracePid, fuzzer);
+            }
         }
     }
 

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -446,11 +446,11 @@ bool arch_archInit(honggfuzz_t * hfuzz)
     }
 
     /*
-     * If sanitizer fuzzing enabled increase number of major frames, since top
-     * 7-9 frames will be occupied with sanitizer symbols if 'abort_on_error'
-     * flag is set
+     * If sanitizer fuzzing enabled and SIGABRT is monitored (abort_on_error=1),
+     * increase number of major frames, since top 7-9 frames will be occupied
+     * with sanitizer runtime library & libc symbols
      */
-    if (hfuzz->monitorSIGABRT) {
+    if (hfuzz->enableSanitizers && hfuzz->monitorSIGABRT) {
         hfuzz->linux.numMajorFrames = 14;
     }
 

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -266,11 +266,7 @@ static struct {
     [SIGBUS].important = true,
     [SIGBUS].descr = "SIGBUS",
 
-#if _HF_MONITOR_SIGABRT
-    [SIGABRT].important = true,
-#else
     [SIGABRT].important = false,
-#endif
     [SIGABRT].descr = "SIGABRT",
 
     [SIGVTALRM].important = true,
@@ -1263,7 +1259,8 @@ void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * f
         /*
          * If it's an interesting signal, save the testcase
          */
-        if (arch_sigs[WSTOPSIG(status)].important) {
+        if (arch_sigs[WSTOPSIG(status)].important
+            || (WSTOPSIG(status) == SIGABRT && hfuzz->monitorSIGABRT == true)) {
             /*
              * If fuzzer worker is from core fuzzing process run full
              * analysis. Otherwise just unwind and get stack hash signature.

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -981,9 +981,6 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
         return;
     }
 
-    /* Local copy since flag is overridden for some crashes */
-    bool saveUnique = hfuzz->saveUnique;
-
     /* Increase global crashes counter */
     ATOMIC_POST_INC(hfuzz->crashesCnt);
     ATOMIC_POST_AND(hfuzz->dynFileIterExpire, _HF_DYNFILE_SUB_MASK);
@@ -1032,39 +1029,14 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
     pc = (uintptr_t) funcs[0].pc;
 
     /*
-     * Check if backtrace contains whitelisted symbol. Whitelist overrides
-     * both stackhash and symbol blacklist. Crash is always kept regardless
-     * of the status of uniqueness flag.
+     * Check if stackhash is blacklisted
      */
-    if (hfuzz->linux.symsWl) {
-        char *wlSymbol = arch_btContainsSymbol(hfuzz->linux.symsWlCnt,
-                                               hfuzz->linux.symsWl, funcCnt, funcs);
-        if (wlSymbol != NULL) {
-            saveUnique = false;
-            LOG_D("Whitelisted symbol '%s' found, skipping blacklist checks", wlSymbol);
-        }
-    } else {
-        /*
-         * Check if stackhash is blacklisted
-         */
-        if (hfuzz->blacklist
-            && (fastArray64Search(hfuzz->blacklist, hfuzz->blacklistCnt, fuzzer->backtrace) !=
-                -1)) {
-            LOG_I("Blacklisted stack hash '%" PRIx64 "', skipping", fuzzer->backtrace);
-            ATOMIC_POST_INC(hfuzz->blCrashesCnt);
-            return;
-        }
-
-        /*
-         * Check if backtrace contains blacklisted symbol
-         */
-        char *blSymbol = arch_btContainsSymbol(hfuzz->linux.symsBlCnt,
-                                               hfuzz->linux.symsBl, funcCnt, funcs);
-        if (blSymbol != NULL) {
-            LOG_I("Blacklisted symbol '%s' found, skipping", blSymbol);
-            ATOMIC_POST_INC(hfuzz->blCrashesCnt);
-            return;
-        }
+    if (hfuzz->blacklist
+        && (fastArray64Search(hfuzz->blacklist, hfuzz->blacklistCnt, fuzzer->backtrace) !=
+            -1)) {
+        LOG_I("Blacklisted stack hash '%" PRIx64 "', skipping", fuzzer->backtrace);
+        ATOMIC_POST_INC(hfuzz->blCrashesCnt);
+        return;
     }
 
     /* If dry run mode, copy file with same name into workspace */
@@ -1073,7 +1045,7 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
                  hfuzz->workDir, fuzzer->origFileName);
     } else {
         /* Keep the crashes file name format identical */
-        if (fuzzer->backtrace != 0ULL && saveUnique) {
+        if (fuzzer->backtrace != 0ULL && hfuzz->saveUnique) {
             snprintf(fuzzer->crashFileName, sizeof(fuzzer->crashFileName),
                      "%s/%s.PC.%" REG_PM ".STACK.%" PRIx64 ".CODE.%s.ADDR.%p.INSTR.%s.%s",
                      hfuzz->workDir, "SAN", pc, fuzzer->backtrace,

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -903,7 +903,7 @@ static int arch_parseAsanReport(honggfuzz_t * hfuzz, pid_t pid, funcs_t * funcs,
                 ++pLineLC;
             }
 
-            /* Separator for crash thread stack trace is an empty line (after trmming \n */
+            /* End separator for crash thread stack trace is an empty line */
             if ((*pLineLC == '\0') && (frameIdx != 0)) {
                 break;
             }
@@ -1087,7 +1087,7 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
 
     /* Generate report */
     fuzzer->report[0] = '\0';
-    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "TYPE: sanitizer exit code crash\n");
+    util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "EXIT_CODE: %s\n", HF_SAN_EXIT_CODE);
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "ORIG_FNAME: %s\n",
                    fuzzer->origFileName);
     util_ssnprintf(fuzzer->report, sizeof(fuzzer->report), "FUZZ_FNAME: %s\n",

--- a/linux/ptrace_utils.c
+++ b/linux/ptrace_utils.c
@@ -1032,8 +1032,7 @@ static void arch_ptraceExitSaveData(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * f
      * Check if stackhash is blacklisted
      */
     if (hfuzz->blacklist
-        && (fastArray64Search(hfuzz->blacklist, hfuzz->blacklistCnt, fuzzer->backtrace) !=
-            -1)) {
+        && (fastArray64Search(hfuzz->blacklist, hfuzz->blacklistCnt, fuzzer->backtrace) != -1)) {
         LOG_I("Blacklisted stack hash '%" PRIx64 "', skipping", fuzzer->backtrace);
         ATOMIC_POST_INC(hfuzz->blCrashesCnt);
         return;

--- a/linux/ptrace_utils.h
+++ b/linux/ptrace_utils.h
@@ -37,5 +37,6 @@ extern bool arch_ptraceAttach(honggfuzz_t * hfuzz, pid_t pid);
 extern void arch_ptraceDetach(pid_t pid);
 extern void arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid, uint64_t * cnt);
 extern void arch_ptraceSetCustomPerf(honggfuzz_t * hfuzz, pid_t pid, uint64_t cnt);
+extern void arch_ptraceSignalsInit(honggfuzz_t * hfuzz);
 
 #endif

--- a/linux/ptrace_utils.h
+++ b/linux/ptrace_utils.h
@@ -32,7 +32,7 @@
 extern bool arch_ptraceWaitForPidStop(pid_t pid);
 extern bool arch_ptraceEnable(honggfuzz_t * hfuzz);
 extern void arch_ptraceAnalyze(honggfuzz_t * hfuzz, int status, pid_t pid, fuzzer_t * fuzzer);
-extern void arch_ptraceExitAnalyze(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzzer, int exitCode);
+extern void arch_ptraceExitAnalyze(honggfuzz_t * hfuzz, pid_t pid, fuzzer_t * fuzzer);
 extern bool arch_ptraceAttach(honggfuzz_t * hfuzz, pid_t pid);
 extern void arch_ptraceDetach(pid_t pid);
 extern void arch_ptraceGetCustomPerf(honggfuzz_t * hfuzz, pid_t pid, uint64_t * cnt);

--- a/mac/arch.c
+++ b/mac/arch.c
@@ -122,9 +122,13 @@ void arch_initSigs(void)
     arch_sigs[SIGSEGV].descr = "SIGSEGV";
     arch_sigs[SIGBUS].important = true;
     arch_sigs[SIGBUS].descr = "SIGBUS";
+
+    /* Is affected from monitorSIGABRT flag */
     arch_sigs[SIGABRT].important = true;
     arch_sigs[SIGABRT].descr = "SIGABRT";
-    arch_sigs[SIGVTALRM].important = true;
+
+    /* Is affected from tmout_vtalrm flag */
+    arch_sigs[SIGVTALRM].important = false;
     arch_sigs[SIGVTALRM].descr = "SIGVTALRM";
 }
 
@@ -472,6 +476,12 @@ bool arch_archInit(honggfuzz_t * hfuzz)
         LOG_F("Parent: could not detach thread to wait for child's exception");
         return false;
     }
+
+    /* Default is true for all platforms except Android */
+    arch_sigs[SIGABRT].important = hfuzz->monitorSIGABRT;
+
+    /* Default is false */
+    arch_sigs[SIGVTALRM].important = hfuzz->tmout_vtalrm;
 
     return true;
 }

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -67,10 +67,12 @@ struct {
     [SIGBUS].important = true,
     [SIGBUS].descr = "SIGBUS",
 
-    [SIGABRT].important = true,
+    /* Is affected from monitorSIGABRT flag */
+    [SIGABRT].important = false,
     [SIGABRT].descr = "SIGABRT",
 
-    [SIGVTALRM].important = true,
+    /* Is affected from tmout_vtalrm flag */
+    [SIGVTALRM].important = false,
     [SIGVTALRM].descr = "SIGVTALRM-TMOUT",
 };
 /*  *INDENT-ON* */
@@ -236,8 +238,14 @@ void arch_reapChild(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
     }
 }
 
-bool arch_archInit(honggfuzz_t * hfuzz UNUSED)
+bool arch_archInit(honggfuzz_t * hfuzz)
 {
+    /* Default is true for all platforms except Android */
+    arch_sigs[SIGABRT].important = hfuzz->monitorSIGABRT;
+
+    /* Default is false */
+    arch_sigs[SIGVTALRM].important = hfuzz->tmout_vtalrm;
+
     return true;
 }
 

--- a/sancov.c
+++ b/sancov.c
@@ -59,60 +59,6 @@
 #define kMagic32 0xC0BFFFFFFFFFFF32
 #define kMagic64 0xC0BFFFFFFFFFFF64
 
-/* Stringify */
-#define XSTR(x)         #x
-#define STR(x)          XSTR(x)
-
-/* Common sanitizer flags */
-#if _HF_MONITOR_SIGABRT
-#define ABORT_FLAG        "abort_on_error=1"
-#else
-#define ABORT_FLAG        "abort_on_error=0"
-#endif
-
-#if defined(__ANDROID__)
-/*
- * symbolize: Disable symbolication since it changes logs (which are parsed) format
- * start_deactivated: Enable on Android to reduce memory usage (useful when not all
- *                    target's DSOs are compiled with sanitizer enabled
- * abort_on_error: Disable for platforms where SIGABRT is not monitored
- */
-#define kSAN_COMMON_ARCH    "symbolize=0:"ABORT_FLAG":start_deactivated=1"
-#else
-#define kSAN_COMMON_ARCH    "symbolize=0:"ABORT_FLAG
-#endif
-
-/* Sanitizer specific flags (set 'abort_on_error has priority over exitcode') */
-#define kASAN_OPTS          "allow_user_segv_handler=1:"\
-                            "handle_segv=0:"\
-                            "allocator_may_return_null=1:"\
-                            kSAN_COMMON_ARCH":exitcode=" STR(HF_ASAN_EXIT_CODE)
-
-#define kUBSAN_OPTS         kSAN_COMMON_ARCH":exitcode=" STR(HF_UBSAN_EXIT_CODE)
-
-#define kMSAN_OPTS          "exit_code=" STR(HF_MSAN_EXIT_CODE) ":"\
-                            "wrap_signals=0:print_stats=1"
-
-/* 'log_path' output directory for sanitizer reports */
-#define kSANLOGDIR          "log_path="
-
-/* 'coverage_dir' output directory for coverage data files is set dynamically */
-#define kSANCOVDIR          "coverage_dir="
-
-/*
- * If the program ends with a signal that ASan does not handle (or can not
- * handle at all, like SIGKILL), coverage data will be lost. This is a big
- * problem on Android, where SIGKILL is a normal way of evicting applications
- * from memory. With 'coverage_direct=1' coverage data is written to a
- * memory-mapped file as soon as it collected. Non-Android targets can disable
- * coverage direct when more coverage data collection methods are implemented.
- */
-#if defined(__ANDROID__)
-#define kSAN_COV_OPTS  "coverage=1:coverage_direct=1"
-#else
-#define kSAN_COV_OPTS  "coverage=1:coverage_direct=1"
-#endif
-
 /*
  * bitmap implementation
  */
@@ -737,87 +683,6 @@ void sancov_Analyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer)
 
 bool sancov_Init(honggfuzz_t * hfuzz)
 {
-    if (hfuzz->linux.pid > 0) {
-        return true;
-    }
-
-    /* Set sanitizer flags once to avoid performance overhead per worker spawn */
-    size_t flagsSz = 0;
-    size_t bufSz = sizeof(kASAN_OPTS) + (2 * PATH_MAX); // Larger constant + 2 dynamic paths
-    char *san_opts = util_Calloc(bufSz);
-    defer {
-        free(san_opts);
-    };
-
-    /* AddressSanitizer (ASan) */
-    if (hfuzz->useSanCov) {
-#if !_HF_MONITOR_SIGABRT
-        /* Write reports in FS only if abort_on_error is disabled */
-        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s:%s%s/%s", kASAN_OPTS, kSAN_COV_OPTS,
-                 kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR, kSANLOGDIR, hfuzz->workDir,
-                 kLOGPREFIX);
-#else
-        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s", kASAN_OPTS, kSAN_COV_OPTS,
-                 kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR);
-#endif
-    } else {
-        snprintf(san_opts, bufSz, "%s:%s%s/%s", kASAN_OPTS, kSANLOGDIR, hfuzz->workDir, kLOGPREFIX);
-    }
-
-    flagsSz = strlen(san_opts) + 1;
-    hfuzz->sanOpts.asanOpts = util_Calloc(flagsSz);
-    memcpy(hfuzz->sanOpts.asanOpts, san_opts, flagsSz);
-    LOG_D("ASAN_OPTIONS=%s", hfuzz->sanOpts.asanOpts);
-
-    /* Undefined Behavior (UBSan) */
-    memset(san_opts, 0, bufSz);
-    if (hfuzz->useSanCov) {
-#if !_HF_MONITOR_SIGABRT
-        /* Write reports in FS only if abort_on_error is disabled */
-        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s:%s%s/%s", kUBSAN_OPTS, kSAN_COV_OPTS,
-                 kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR, kSANLOGDIR, hfuzz->workDir,
-                 kLOGPREFIX);
-#else
-        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s", kUBSAN_OPTS, kSAN_COV_OPTS,
-                 kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR);
-#endif
-    } else {
-        snprintf(san_opts, bufSz, "%s:%s%s/%s", kUBSAN_OPTS, kSANLOGDIR, hfuzz->workDir,
-                 kLOGPREFIX);
-    }
-
-    flagsSz = strlen(san_opts) + 1;
-    hfuzz->sanOpts.ubsanOpts = util_Calloc(flagsSz);
-    memcpy(hfuzz->sanOpts.ubsanOpts, san_opts, flagsSz);
-    LOG_D("UBSAN_OPTIONS=%s", hfuzz->sanOpts.ubsanOpts);
-
-    /* MemorySanitizer (MSan) */
-    memset(san_opts, 0, bufSz);
-    const char *msan_reports_flag = "report_umrs=0";
-    if (hfuzz->msanReportUMRS) {
-        msan_reports_flag = "report_umrs=1";
-    }
-
-    if (hfuzz->useSanCov) {
-#if !_HF_MONITOR_SIGABRT
-        /* Write reports in FS only if abort_on_error is disabled */
-        snprintf(san_opts, bufSz, "%s:%s:%s:%s%s/%s:%s%s/%s", kMSAN_OPTS, msan_reports_flag,
-                 kSAN_COV_OPTS, kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR, kSANLOGDIR,
-                 hfuzz->workDir, kLOGPREFIX);
-#else
-        snprintf(san_opts, bufSz, "%s:%s:%s:%s%s/%s", kMSAN_OPTS, msan_reports_flag,
-                 kSAN_COV_OPTS, kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR);
-#endif
-    } else {
-        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s", kMSAN_OPTS, msan_reports_flag, kSANLOGDIR,
-                 hfuzz->workDir, kLOGPREFIX);
-    }
-
-    flagsSz = strlen(san_opts) + 1;
-    hfuzz->sanOpts.msanOpts = util_Calloc(flagsSz);
-    memcpy(hfuzz->sanOpts.msanOpts, san_opts, flagsSz);
-    LOG_D("MSAN_OPTIONS=%s", hfuzz->sanOpts.msanOpts);
-
     if (hfuzz->useSanCov == false) {
         return true;
     }
@@ -828,35 +693,6 @@ bool sancov_Init(honggfuzz_t * hfuzz)
     if (!files_exists(sanCovOutDir)) {
         if (mkdir(sanCovOutDir, S_IRWXU | S_IXGRP | S_IXOTH) != 0) {
             PLOG_E("mkdir() '%s' failed", sanCovOutDir);
-        }
-    }
-
-    return true;
-}
-
-bool sancov_prepareExecve(honggfuzz_t * hfuzz)
-{
-    /* Address Sanitizer (ASan) */
-    if (hfuzz->sanOpts.asanOpts) {
-        if (setenv("ASAN_OPTIONS", hfuzz->sanOpts.asanOpts, 1) == -1) {
-            PLOG_E("setenv(ASAN_OPTIONS) failed");
-            return false;
-        }
-    }
-
-    /* Memory Sanitizer (MSan) */
-    if (hfuzz->sanOpts.msanOpts) {
-        if (setenv("MSAN_OPTIONS", hfuzz->sanOpts.msanOpts, 1) == -1) {
-            PLOG_E("setenv(MSAN_OPTIONS) failed");
-            return false;
-        }
-    }
-
-    /* Undefined Behavior Sanitizer (UBSan) */
-    if (hfuzz->sanOpts.ubsanOpts) {
-        if (setenv("UBSAN_OPTIONS", hfuzz->sanOpts.ubsanOpts, 1) == -1) {
-            PLOG_E("setenv(UBSAN_OPTIONS) failed");
-            return false;
         }
     }
 

--- a/sanitizers.c
+++ b/sanitizers.c
@@ -1,0 +1,209 @@
+#include "common.h"
+#include "sanitizers.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "files.h"
+#include "log.h"
+#include "util.h"
+
+/* Stringify */
+#define XSTR(x)         #x
+#define STR(x)          XSTR(x)
+
+/*
+ * All clang sanitizers except ASan can be activated for target binaries
+ * with or without the matching runtime libraries (libcompiler_rt). If runtime
+ * libraries are included in target fuzzing environment, we can benefit from the
+ * various Die() callbacks and abort/exit logic manipulation. However, some
+ * setups (e.g. Android production ARM/ARM64 devices) enable sanitizers such as
+ * UBSan without the runtime libraries. As such they default ftrap is activated
+ * which is for most cases a SIGABRT. For such cases user needs to enable SIGABRT
+ * monitoring flag, otherwise these crashes will be missed.
+ *
+ * Normally SIGABRT is not a monitored signal for Android OS, since it produces
+ * lots of useless crashes due to way Android process termination hacks work. As
+ * a result the sanitizer's 'abort_on_error' flag cannot be utilized since it
+ * invokes abort() internally. In order to not lose crashes a custom exitcode can
+ * be registered and monitored. Since exitcode is a global flag, it's assumed
+ * that target is compiled with only one sanitizer type enabled at a time.
+ *
+ * For cases where clang runtime library linking is not an option SIGABRT should
+ * be monitored even for noise targets, such as the Android OS, since not
+ * alternative exists.
+ */
+
+/* 'log_path' output directory for sanitizer reports */
+#define kSANLOGDIR          "log_path="
+
+/* 'coverage_dir' output directory for coverage data files is set dynamically */
+#define kSANCOVDIR          "coverage_dir="
+
+/* Raise SIGABRT on error or continue with exitcode logic */
+#define kABORT_ENABLED      "abort_on_error=1"
+#define kABORT_DISABLED     "abort_on_error=0"
+
+/*
+ * Common sanitizer flags
+ *
+ * symbolize: Disable symbolication since it changes logs (which are parsed) format
+ */
+#define kSAN_COMMON         "symbolize=0"
+
+/* --{ ASan }-- */
+/*
+ *Sanitizer specific flags (notice that if enabled 'abort_on_error' has priority
+ * over exitcode')
+ */
+#define kASAN_COMMON_OPTS   "allow_user_segv_handler=1:"\
+                            "handle_segv=0:"\
+                            "allocator_may_return_null=1:"\
+                            kSAN_COMMON":exitcode=" STR(HF_ASAN_EXIT_CODE)
+/* Platform specific flags */
+#if defined(__ANDROID__)
+/*
+ * start_deactivated: Enable on Android to reduce memory usage (useful when not all
+ *                    target's DSOs are compiled with sanitizer enabled
+ */
+#define kASAN_OPTS          kASAN_COMMON_OPTS":start_deactivated=1"
+#else
+#define kASAN_OPTS          kASAN_COMMON_OPTS
+#endif
+
+/* --{ UBSan }-- */
+#define kUBSAN_OPTS         kSAN_COMMON":exitcode=" STR(HF_UBSAN_EXIT_CODE)
+
+/* --{ MSan }-- */
+#define kMSAN_OPTS          kSAN_COMMON":exit_code=" STR(HF_MSAN_EXIT_CODE) ":"\
+                            "wrap_signals=0:print_stats=1"
+
+/*
+ * If the program ends with a signal that ASan does not handle (or can not
+ * handle at all, like SIGKILL), coverage data will be lost. This is a big
+ * problem on Android, where SIGKILL is a normal way of evicting applications
+ * from memory. With 'coverage_direct=1' coverage data is written to a
+ * memory-mapped file as soon as it collected. Non-Android targets can disable
+ * coverage direct when more coverage data collection methods are implemented.
+ */
+#define kSAN_COV_OPTS  "coverage=1:coverage_direct=1"
+
+bool sanitizers_Init(honggfuzz_t * hfuzz)
+{
+    if (hfuzz->linux.pid > 0 || hfuzz->enableSanitizers == false) {
+        return true;
+    }
+
+    /* Set sanitizer flags once to avoid performance overhead per worker spawn */
+    size_t flagsSz = 0;
+
+    /* Larger constant combination + 2 dynamic paths */
+    size_t bufSz =
+        sizeof(kASAN_OPTS) + 1 + sizeof(kABORT_ENABLED) + 1 + sizeof(kSANLOGDIR) + PATH_MAX + 1 +
+        sizeof(kSANCOVDIR) + PATH_MAX + 1;
+    char *san_opts = util_Calloc(bufSz);
+    defer {
+        free(san_opts);
+    };
+
+    char *abortFlag;
+    if (hfuzz->monitorSIGABRT) {
+        abortFlag = kABORT_ENABLED;
+    } else {
+        abortFlag = kABORT_DISABLED;
+    }
+
+    /* AddressSanitizer (ASan) */
+    if (hfuzz->useSanCov) {
+        snprintf(san_opts, bufSz, "%s:%s:%s:%s%s/%s:%s%s/%s", kASAN_OPTS, abortFlag, kSAN_COV_OPTS,
+                 kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR, kSANLOGDIR, hfuzz->workDir,
+                 kLOGPREFIX);
+    } else {
+        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s", kASAN_OPTS, abortFlag, kSANLOGDIR,
+                 hfuzz->workDir, kLOGPREFIX);
+    }
+
+    flagsSz = strlen(san_opts) + 1;
+    hfuzz->sanOpts.asanOpts = util_Calloc(flagsSz);
+    memcpy(hfuzz->sanOpts.asanOpts, san_opts, flagsSz);
+    LOG_D("ASAN_OPTIONS=%s", hfuzz->sanOpts.asanOpts);
+
+    /* Undefined Behavior (UBSan) */
+    memset(san_opts, 0, bufSz);
+    if (hfuzz->useSanCov) {
+        snprintf(san_opts, bufSz, "%s:%s:%s:%s%s/%s:%s%s/%s", kUBSAN_OPTS, abortFlag, kSAN_COV_OPTS,
+                 kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR, kSANLOGDIR, hfuzz->workDir,
+                 kLOGPREFIX);
+    } else {
+        snprintf(san_opts, bufSz, "%s:%s:%s%s/%s", kUBSAN_OPTS, abortFlag, kSANLOGDIR,
+                 hfuzz->workDir, kLOGPREFIX);
+    }
+
+    flagsSz = strlen(san_opts) + 1;
+    hfuzz->sanOpts.ubsanOpts = util_Calloc(flagsSz);
+    memcpy(hfuzz->sanOpts.ubsanOpts, san_opts, flagsSz);
+    LOG_D("UBSAN_OPTIONS=%s", hfuzz->sanOpts.ubsanOpts);
+
+    /* MemorySanitizer (MSan) */
+    memset(san_opts, 0, bufSz);
+    const char *msan_reports_flag = "report_umrs=0";
+    if (hfuzz->msanReportUMRS) {
+        msan_reports_flag = "report_umrs=1";
+    }
+
+    if (hfuzz->useSanCov) {
+        snprintf(san_opts, bufSz, "%s:%s:%s:%s:%s%s/%s:%s%s/%s", kMSAN_OPTS, abortFlag,
+                 msan_reports_flag, kSAN_COV_OPTS, kSANCOVDIR, hfuzz->workDir, _HF_SANCOV_DIR,
+                 kSANLOGDIR, hfuzz->workDir, kLOGPREFIX);
+    } else {
+        snprintf(san_opts, bufSz, "%s:%s:%s:%s%s/%s", kMSAN_OPTS, abortFlag, msan_reports_flag,
+                 kSANLOGDIR, hfuzz->workDir, kLOGPREFIX);
+    }
+
+    flagsSz = strlen(san_opts) + 1;
+    hfuzz->sanOpts.msanOpts = util_Calloc(flagsSz);
+    memcpy(hfuzz->sanOpts.msanOpts, san_opts, flagsSz);
+    LOG_D("MSAN_OPTIONS=%s", hfuzz->sanOpts.msanOpts);
+
+    return true;
+}
+
+bool sanitizers_prepareExecve(honggfuzz_t * hfuzz)
+{
+    if (hfuzz->enableSanitizers == false) {
+        return true;
+    }
+
+    /* Address Sanitizer (ASan) */
+    if (hfuzz->sanOpts.asanOpts) {
+        if (setenv("ASAN_OPTIONS", hfuzz->sanOpts.asanOpts, 1) == -1) {
+            PLOG_E("setenv(ASAN_OPTIONS) failed");
+            return false;
+        }
+    }
+
+    /* Memory Sanitizer (MSan) */
+    if (hfuzz->sanOpts.msanOpts) {
+        if (setenv("MSAN_OPTIONS", hfuzz->sanOpts.msanOpts, 1) == -1) {
+            PLOG_E("setenv(MSAN_OPTIONS) failed");
+            return false;
+        }
+    }
+
+    /* Undefined Behavior Sanitizer (UBSan) */
+    if (hfuzz->sanOpts.ubsanOpts) {
+        if (setenv("UBSAN_OPTIONS", hfuzz->sanOpts.ubsanOpts, 1) == -1) {
+            PLOG_E("setenv(UBSAN_OPTIONS) failed");
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/sanitizers.c
+++ b/sanitizers.c
@@ -20,24 +20,24 @@
 #define STR(x)          XSTR(x)
 
 /*
- * All clang sanitizers except ASan can be activated for target binaries
- * with or without the matching runtime libraries (libcompiler_rt). If runtime
+ * All clang sanitizers, except ASan, can be activated for target binaries
+ * with or without the matching runtime library (libcompiler_rt). If runtime
  * libraries are included in target fuzzing environment, we can benefit from the
  * various Die() callbacks and abort/exit logic manipulation. However, some
- * setups (e.g. Android production ARM/ARM64 devices) enable sanitizers such as
- * UBSan without the runtime libraries. As such they default ftrap is activated
- * which is for most cases a SIGABRT. For such cases user needs to enable SIGABRT
- * monitoring flag, otherwise these crashes will be missed.
+ * setups (e.g. Android production ARM/ARM64 devices) enable sanitizers, such as
+ * UBSan, without the runtime libraries. As such, their default ftrap is activated
+ * which is for most cases a SIGABRT. For these cases end-user needs to enable
+ * SIGABRT monitoring flag, otherwise these crashes will be missed.
  *
- * Normally SIGABRT is not a monitored signal for Android OS, since it produces
+ * Normally SIGABRT is not a wanted signal to monitor for Android, since it produces
  * lots of useless crashes due to way Android process termination hacks work. As
  * a result the sanitizer's 'abort_on_error' flag cannot be utilized since it
  * invokes abort() internally. In order to not lose crashes a custom exitcode can
  * be registered and monitored. Since exitcode is a global flag, it's assumed
  * that target is compiled with only one sanitizer type enabled at a time.
  *
- * For cases where clang runtime library linking is not an option SIGABRT should
- * be monitored even for noise targets, such as the Android OS, since not
+ * For cases where clang runtime library linking is not an option, SIGABRT should
+ * be monitored even for noisy targets, such as the Android OS, since no viable
  * alternative exists.
  *
  * There might be cases where ASan instrumented targets crash while generating

--- a/sanitizers.c
+++ b/sanitizers.c
@@ -74,7 +74,7 @@
 #define kASAN_COMMON_OPTS   "allow_user_segv_handler=1:"\
                             "handle_segv=0:"\
                             "allocator_may_return_null=1:"\
-                            kSAN_COMMON":exitcode=" STR(HF_ASAN_EXIT_CODE)
+                            kSAN_COMMON":exitcode=" STR(HF_SAN_EXIT_CODE)
 /* Platform specific flags */
 #if defined(__ANDROID__)
 /*
@@ -87,10 +87,10 @@
 #endif
 
 /* --{ UBSan }-- */
-#define kUBSAN_OPTS         kSAN_COMMON":exitcode=" STR(HF_UBSAN_EXIT_CODE)
+#define kUBSAN_OPTS         kSAN_COMMON":exitcode=" STR(HF_SAN_EXIT_CODE)
 
 /* --{ MSan }-- */
-#define kMSAN_OPTS          kSAN_COMMON":exit_code=" STR(HF_MSAN_EXIT_CODE) ":"\
+#define kMSAN_OPTS          kSAN_COMMON":exit_code=" STR(HF_SAN_EXIT_CODE) ":"\
                             "wrap_signals=0:print_stats=1"
 
 /*

--- a/sanitizers.h
+++ b/sanitizers.h
@@ -1,6 +1,6 @@
 /*
  *
- * honggfuzz - sanitizer coverage feedback parsing
+ * honggfuzz - sanitizers configuration
  * -----------------------------------------------
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -17,16 +17,21 @@
  *
  */
 
-#ifndef _HF_SANCOV_H_
-#define _HF_SANCOV_H_
+#ifndef _HF_SANITIZERS_H_
+#define _HF_SANITIZERS_H_
 
-#include "sanitizers.h"
+#define HF_MSAN_EXIT_CODE   103
+#define HF_ASAN_EXIT_CODE   104
+#define HF_UBSAN_EXIT_CODE  105
 
-/* Bitmap size */
-#define _HF_SANCOV_BITMAP_SIZE 0x3FFFFFF
+/* Prefix for sanitizer report files */
+#define kLOGPREFIX          "HF.sanitizer.log"
 
-extern void sancov_Analyze(honggfuzz_t * hfuzz, fuzzer_t * fuzzer);
+/* Directory in workspace to store sanitizer coverage data */
+#define _HF_SANCOV_DIR "HF_SANCOV"
 
-extern bool sancov_Init(honggfuzz_t * hfuzz);
+extern bool sanitizers_Init(honggfuzz_t * hfuzz);
 
-#endif                          /* _HF_SANCOV_H_ */
+extern bool sanitizers_prepareExecve(honggfuzz_t * hfuzz);
+
+#endif                          /* _HF_SANITIZERS_H_ */

--- a/sanitizers.h
+++ b/sanitizers.h
@@ -20,9 +20,8 @@
 #ifndef _HF_SANITIZERS_H_
 #define _HF_SANITIZERS_H_
 
-#define HF_MSAN_EXIT_CODE   103
-#define HF_ASAN_EXIT_CODE   104
-#define HF_UBSAN_EXIT_CODE  105
+/* Exit code is common for all sanitizers */
+#define HF_SAN_EXIT_CODE   103
 
 /* Prefix for sanitizer report files */
 #define kLOGPREFIX          "HF.sanitizer.log"

--- a/subproc.c
+++ b/subproc.c
@@ -181,8 +181,8 @@ bool subproc_PrepareExecv(honggfuzz_t * hfuzz, fuzzer_t * fuzzer, const char *fi
     if (hfuzz->clearEnv) {
         environ = NULL;
     }
-    if (sancov_prepareExecve(hfuzz) == false) {
-        LOG_E("sancov_prepareExecve() failed");
+    if (sanitizers_prepareExecve(hfuzz) == false) {
+        LOG_E("sanitizers_prepareExecve() failed");
         return false;
     }
     for (size_t i = 0; i < ARRAYSIZE(hfuzz->envs) && hfuzz->envs[i]; i++) {


### PR DESCRIPTION
* Separate sanitizers env config from sanitizers coverage
* Refactor SIGABRT monitor logic & sanitizers exit-code strategy
* Export flags to control sanitizers + SIGABRT
* Simplified the sanitizer env preparation
* Fixed small bugs around sanitizers logic

Commit messages & comments inside `sanitizers.c` provide a detailed insight of the changes. Most of the spotted bugs (missing crashes) were affecting targets were SIGABRT was not monitored.

Current changes have been heavily tested against latest Android 7.1 using Android NDK R13b.