### PR TITLE
Fix paths for examples

### DIFF
--- a/examples/badcode/run-honggfuzz-on-badcode1-with-externalfuzzer.sh
+++ b/examples/badcode/run-honggfuzz-on-badcode1-with-externalfuzzer.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-../honggfuzz -n1 -u -f inputfiles/badcode1.txt -c externalfuzzers/lowBytesIncrease.py -- targets/badcode1 ___FILE___
+../../honggfuzz -n1 -u -f inputfiles -c ../externalfuzzers/lowBytesIncrease.py -- targets/badcode1 ___FILE___

--- a/examples/badcode/run-honggfuzz-on-badcode1.sh
+++ b/examples/badcode/run-honggfuzz-on-badcode1.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-../honggfuzz -n1 -u -f inputfiles/badcode1.txt -- targets/badcode1 ___FILE___
+../../honggfuzz -n1 -u -f inputfiles -- targets/badcode1 ___FILE___


### PR DESCRIPTION
Update for outdated paths.

Also, I think that at some point loading corpus files for external fuzzers have changed. For version <= 0.7 you can provide argument `-f inputfiles/badcode1.txt` however later versions break on this (but work for just the directory).