### PR TITLE
[macOS clang] fix libhfuzz compilation issue

### DIFF
--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -179,13 +179,13 @@ ATTRIBUTE_X86_REQUIRE_SSE42 void __sanitizer_cov_trace_cmp(uint64_t SizeAndType,
     uint64_t CmpSize = (SizeAndType >> 32) / 8;
     switch (CmpSize) {
     case (sizeof(uint8_t)):
-        return __sanitizer_cov_trace_cmp1(Arg1, Arg2);
+        __sanitizer_cov_trace_cmp1(Arg1, Arg2);
     case (sizeof(uint16_t)):
-        return __sanitizer_cov_trace_cmp2(Arg1, Arg2);
+        __sanitizer_cov_trace_cmp2(Arg1, Arg2);
     case (sizeof(uint32_t)):
-        return __sanitizer_cov_trace_cmp4(Arg1, Arg2);
+        __sanitizer_cov_trace_cmp4(Arg1, Arg2);
     case (sizeof(uint64_t)):
-        return __sanitizer_cov_trace_cmp8(Arg1, Arg2);
+        __sanitizer_cov_trace_cmp8(Arg1, Arg2);
     }
 }
 


### PR DESCRIPTION
Fixes a void return expression issue when compiling with clang. Issue was
spotted against macOS and was introduced by commit
https://github.com/google/honggfuzz/commit/d51cd3fb934d991c9867b5c684479402334d0530

```
libhfuzz/instrument.c:182:9: error: void function '__sanitizer_cov_trace_cmp' should not return void expression [-Werror,-Wpedantic]
        return __sanitizer_cov_trace_cmp1(Arg1, Arg2);
        ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libhfuzz/instrument.c:184:9: error: void function '__sanitizer_cov_trace_cmp' should not return void expression [-Werror,-Wpedantic]
        return __sanitizer_cov_trace_cmp2(Arg1, Arg2);
        ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libhfuzz/instrument.c:186:9: error: void function '__sanitizer_cov_trace_cmp' should not return void expression [-Werror,-Wpedantic]
        return __sanitizer_cov_trace_cmp4(Arg1, Arg2);
        ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libhfuzz/instrument.c:188:9: error: void function '__sanitizer_cov_trace_cmp' should not return void expression [-Werror,-Wpedantic]
        return __sanitizer_cov_trace_cmp8(Arg1, Arg2);
        ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4 errors generated.
make: *** [libhfuzz/instrument.o] Error 1

```