### PR TITLE
Do not setenv("OPENSSL_armcap") if OPENSSL_ARMCAP_ABI is zero

### DIFF
--- a/linux/arch.c
+++ b/linux/arch.c
@@ -458,7 +458,7 @@ bool arch_archInit(honggfuzz_t * hfuzz)
             return false;
         }
     }
-#if defined(__ANDROID__) && defined(__arm__)
+#if defined(__ANDROID__) && defined(__arm__) && defined(OPENSSL_ARMCAP_ABI)
     /*
      * For ARM kernels running Android API <= 21, if fuzzing target links to
      * libcrypto (OpenSSL), OPENSSL_cpuid_setup initialization is triggering a


### PR DESCRIPTION
It seems like we always set `OPENSSL_ARMCAP_ABI` -- but on newer versions with BoringSSL, this is not necessary (per the docs).  However, the variable is still set and appears to override `OPENSSL_armcap_P` in the BoringSSL source.

We should change this so that we can build without `-DOPENSSL_ARMCAP_ABI=X` (since it shouldn't be needed on newer Android builds) and avoid the `setenv` call entirely.