### PR TITLE
Update httpd-master.honggfuzz.patch

### DIFF
--- a/examples/apache/httpd-master.honggfuzz.patch
+++ b/examples/apache/httpd-master.honggfuzz.patch
@@ -42,7 +42,7 @@ index 0000000..690d91f
 +
 +echo "Compiling NGHTTP2"
 +cd "$NGHTTP2_PATH"
-+CFLAGS="$CFLAGS_SAN" CXXLAGS="$CFLAGS_SAN" ./configure --disable-shared --enable-static
++CFLAGS="$CFLAGS_SAN" CXXFLAGS="$CFLAGS_SAN" ./configure --disable-shared --enable-static
 +make clean
 +make -j$(nproc)
 +cd -


### PR DESCRIPTION
"CXXLAGS" should be "CXXFLAGS"
does not cause problem when -fsanitizer=address
but report error when set to -fsanitizer=thread