### PR TITLE
android: NDK r16 compatibility & switch default to clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ endif
 # Control Android builds
 ANDROID_API           ?= android-24
 ANDROID_DEBUG_ENABLED ?= false
-ANDROID_CLANG         ?= false
+ANDROID_CLANG         ?= true
 ANDROID_APP_ABI       ?= armeabi-v7a
 ANDROID_SKIP_CLEAN    ?= false
 NDK_BUILD_ARGS :=
@@ -198,6 +198,7 @@ ifeq ($(ANDROID_SKIP_CLEAN),true)
 endif
 
 ifeq ($(ANDROID_CLANG),true)
+  ANDROID_NDK_TOOLCHAIN_VER := clang
   # clang works only against APIs >= 23
   ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),armeabi armeabi-v7a))
     ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-clang
@@ -215,6 +216,7 @@ ifeq ($(ANDROID_CLANG),true)
     $(error Unsuported / Unknown APP_API '$(ANDROID_APP_ABI)')
   endif
 else
+  ANDROID_NDK_TOOLCHAIN_VER := 4.9
   ifeq ($(ANDROID_APP_ABI),$(filter $(ANDROID_APP_ABI),armeabi armeabi-v7a))
     ANDROID_NDK_TOOLCHAIN ?= arm-linux-androideabi-4.9
     ANDROID_ARCH_CPU := arm
@@ -303,8 +305,8 @@ android:
 
 	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./android/Android.mk \
     APP_PLATFORM=$(ANDROID_API) APP_ABI=$(ANDROID_APP_ABI) \
-    NDK_TOOLCHAIN=$(ANDROID_NDK_TOOLCHAIN) $(NDK_BUILD_ARGS) \
-    APP_MODULES='honggfuzz hfuzz'
+    NDK_TOOLCHAIN=$(ANDROID_NDK_TOOLCHAIN) NDK_TOOLCHAIN_VERSION=$(ANDROID_NDK_TOOLCHAIN_VER) \
+    $(NDK_BUILD_ARGS) APP_MODULES='honggfuzz hfuzz'
 
 # Loop all ABIs and pass-through flags since visibility is lost due to sub-process
 .PHONY: android-all

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -17,7 +17,7 @@ build an upstream git fork is executed
 
 | **Dependency** | **Last Tested Version** |
 |:-------|:-----------|
-| **Android NDK** | r15 with Android API 24 (Nougat 7.0) |
+| **Android NDK** | r16 with Android API 24 (Nougat 7.0) |
 | **libunwind** | upstream master commit [bc8698f] |
 | **capstone** | 3.0.4 stable version |
 
@@ -115,7 +115,7 @@ Were `<arch>` can be:
 | **ANDROID_APP_ABI** | armeabi, armeabi-v7a, arm64-v8a, x86, x86_64 (default: armeabi-v7a) | Target CPU |
 | **ANDROID_WITH_PTRACE** | true, false (default: true) `1`| Fuzzing engine backend architecture |
 | **ANDROID_API** | android-21, android-22, ... (default: android-24) `2` | Target Android API |
-| **ANDROID_CLANG** | true, false (default: false) | Android NDK compiler toolchain to use |
+| **ANDROID_CLANG** | true, false (default: true) | Android NDK compiler toolchain to use |
 
 _`1`) If false, POSIX signals interface is used instead of PTRACE API_
 


### PR DESCRIPTION
Android NDK r16 deprecates (although doesn't remove yet) the gcc 4.9 support.
However, some toolchain flags have been altered thus need the
`ANDROID_NDK_TOOLCHAIN_VER` flag to be also set to effectively select gcc
over default clang.

This commit is also switching the default compiler selection from gcc to clang. It
has been tested the past few months and no issues surfaced so far against
various aarch64 Android targets.