### PR TITLE
Allow multiple calls to __sanitizer_cov_trace_pc_guard_init

### DIFF
--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -216,11 +216,8 @@ ATTRIBUTE_X86_REQUIRE_SSE42 void __sanitizer_cov_indir_call16(
  */
 ATTRIBUTE_X86_REQUIRE_SSE42 void __sanitizer_cov_trace_pc_guard_init(
     uint32_t* start, uint32_t* stop) {
-    if (guards_initialized == true) {
-        return;
-    }
     guards_initialized = true;
-    uint32_t n = 1U;
+    static uint32_t n = 1U;
     for (uint32_t* x = start; x < stop; x++, n++) {
         if (n >= _HF_PC_GUARD_MAX) {
             LOG_F("This process has too many PC guards: %tx\n",


### PR DESCRIPTION
The documentation (1) states:

    // This callback is inserted by the compiler as a module constructor
    // into every DSO. 'start' and 'stop' correspond to the
    // beginning and end of the section with the guards for the entire
    // binary (executable or DSO). The callback will be called at least
    // once per DSO and may be called multiple times with the same parameters

1: https://clang.llvm.org/docs/SanitizerCoverage.html

Change-Id: Ic6f5522338248ca4572911cd5c9f40d6358894b3