### PR TITLE
Support external fuzzer and provide code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ android-clean-deps:
 	done
 
 # DO NOT DELETE
-
+socketfuzzer.o: socketfuzzer.h
 cmdline.o: cmdline.h honggfuzz.h libhfcommon/util.h libhfcommon/common.h
 cmdline.o: libhfcommon/files.h libhfcommon/common.h libhfcommon/log.h
 display.o: display.h honggfuzz.h libhfcommon/util.h libhfcommon/common.h

--- a/cmdline.c
+++ b/cmdline.c
@@ -304,6 +304,8 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
 
         .feedback_mutex = PTHREAD_MUTEX_INITIALIZER,
 
+        .socketFuzzer = false,
+
         .cnts =
             {
                 .mutationsCnt = 0,
@@ -411,6 +413,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "monitor_sigabrt", required_argument, NULL, 0x105 }, "Monitor SIGABRT (default: 'false for Android - 'true for other platforms)" },
         { { "no_fb_timeout", required_argument, NULL, 0x106 }, "Skip feedback if the process has timeouted (default: 'false')" },
         { { "exit_upon_crash", no_argument, NULL, 0x107 }, "Exit upon seeing the first crash (default: 'false')" },
+        { { "socket_fuzzer", no_argument, NULL, 0x10b }, "Instrument external fuzzer via socket" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blacklist filter file (one entry per line)" },
@@ -513,6 +516,10 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 break;
             case 0x10A:
                 hfuzz->extSanOpts = optarg;
+                break;
+            case 0x10B:
+                hfuzz->socketFuzzer = true;
+                hfuzz->timing.tmOut = 0; // Disable process timeout checks
                 break;
             case 'z':
                 hfuzz->dynFileMethod |= _HF_DYNFILE_SOFT;

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -39,6 +39,7 @@
 #include "display.h"
 #include "fuzz.h"
 #include "input.h"
+#include "socketfuzzer.h"
 #include "libhfcommon/common.h"
 #include "libhfcommon/files.h"
 #include "libhfcommon/log.h"
@@ -172,7 +173,11 @@ int main(int argc, char** argv) {
         display_init();
     }
 
-    if (!input_init(&hfuzz)) {
+    if (hfuzz.socketFuzzer) {
+        LOG_I("No input file corpus loaded, the external socket_fuzzer is responsible for "
+              "creating the fuzz data");
+        setupSocketFuzzer(&hfuzz);
+    } else if (!input_init(&hfuzz)) {
         LOG_F("Couldn't load input corpus");
         exit(EXIT_FAILURE);
     }
@@ -246,6 +251,9 @@ int main(int argc, char** argv) {
     }
     if (hfuzz.linux.symsWl) {
         free(hfuzz.linux.symsWl);
+    }
+    if (hfuzz.socketFuzzer) {
+        cleanupSocketFuzzer();
     }
 
     return EXIT_SUCCESS;

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -247,6 +247,8 @@ typedef struct {
 
     pthread_mutex_t feedback_mutex;
 
+    bool socketFuzzer;
+
     struct {
         size_t mutationsCnt;
         size_t crashesCnt;
@@ -288,6 +290,11 @@ typedef struct {
         bool useClone;
         sigset_t waitSigSet;
     } linux;
+
+    struct {
+        int serverSocket;
+        int clientSocket;
+    } socketFuzzerData;
 } honggfuzz_t;
 
 typedef struct {
@@ -328,6 +335,8 @@ typedef struct {
         int cpuBranchFd;
         int cpuIptBtsFd;
     } linux;
+
+    bool hasCrashed;
 } run_t;
 
 /*

--- a/linux/arch.c
+++ b/linux/arch.c
@@ -65,6 +65,9 @@ static inline bool arch_shouldAttach(run_t* run) {
     if (run->global->linux.pid > 0 && run->linux.attachedPid == run->global->linux.pid) {
         return false;
     }
+    if (run->global->socketFuzzer && run->linux.attachedPid == run->pid) {
+        return false;
+    }
     return true;
 }
 
@@ -342,6 +345,12 @@ void arch_reapChild(run_t* run) {
             break;
         }
         if (arch_checkWait(run)) {
+            LOG_D("SocketFuzzer: arch: Crash Identified");
+            run->hasCrashed = true;
+            break;
+        }
+        if (run->global->socketFuzzer) {
+            // Do not wait for new events
             break;
         }
     }

--- a/socketfuzzer.c
+++ b/socketfuzzer.c
@@ -1,0 +1,172 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "honggfuzz.h"
+#include "libhfcommon/common.h"
+#include "libhfcommon/files.h"
+#include "libhfcommon/log.h"
+#include "libhfcommon/ns.h"
+#include "libhfcommon/util.h"
+
+#include "socketfuzzer.h"
+
+
+bool fuzz_waitForExternalInput(run_t* run) {
+    /* tell the external fuzzer to do his thing */
+    if (!fuzz_prepareSocketFuzzer(run)) {
+        LOG_F("fuzz_prepareSocketFuzzer() failed");
+        return false;
+    }
+
+    /* the external fuzzer may inform us of a crash */
+    int result = fuzz_waitforSocketFuzzer(run);
+    if (result == 2) {
+        return false;
+    }
+
+    return true;
+}
+
+bool fuzz_prepareSocketFuzzer(run_t* run)
+{
+    ssize_t ret;
+
+    // Notify fuzzer that he should send teh things
+    LOG_D("fuzz_prepareSocketFuzzer: SEND Fuzz");
+    ret = send(run->global->socketFuzzerData.clientSocket, "Fuzz", 4, 0);
+    if(ret < 0) {
+        LOG_F("fuzz_prepareSocketFuzzer: received: %ld", ret);
+        return false;
+    }
+
+    return true;
+}
+
+/* Return values:
+    0: error
+    1: okay
+    2: target unresponsive
+*/
+int fuzz_waitforSocketFuzzer(run_t* run)
+{
+    ssize_t ret;
+    char buf[16];
+
+    // Wait until the external fuzzer did his thing
+    bzero(buf, 16);
+    ret = recv(run->global->socketFuzzerData.clientSocket, buf, 4, 0);
+    LOG_D("fuzz_waitforSocketFuzzer: RECV: %s", buf);
+
+    // We dont care what we receive, its just to block here
+    if(ret < 0) {
+        LOG_F("fuzz_waitforSocketFuzzer: received: %ld", ret);
+        return 0;
+    }
+
+    if(memcmp(buf, "okay", 4) == 0) {
+        return 1;
+    } else if(memcmp(buf, "bad!", 4) == 0) {
+        return 2;
+    }
+
+    return 0;
+}
+
+bool fuzz_notifySocketFuzzerNewCov(honggfuzz_t *hfuzz)
+{
+    ssize_t ret;
+
+    // Tell the fuzzer that the thing he sent reached new BB's
+    ret = send(hfuzz->socketFuzzerData.clientSocket, "New!", 4, 0);
+    LOG_D("fuzz_notifySocketFuzzer: SEND: New!");
+    if(ret < 0) {
+        LOG_F("fuzz_notifySocketFuzzer: sent: %ld", ret);
+        return false;
+    }
+
+    return true;
+}
+
+bool fuzz_notifySocketFuzzerCrash(run_t* run)
+{
+    ssize_t ret;
+
+    ret = send(run->global->socketFuzzerData.clientSocket, "Cras", 4, 0);
+    LOG_D("fuzz_notifySocketFuzzer: SEND: Crash");
+    if(ret < 0) {
+        LOG_F("fuzz_notifySocketFuzzer: sent: %ld", ret);
+        return false;
+    }
+
+    return true;
+}
+
+bool setupSocketFuzzer(honggfuzz_t *run) {
+    int s, len;
+    socklen_t t;
+    struct sockaddr_un local, remote;
+    char socketPath[512];
+    //snprintf(socketPath, sizeof(socketPath), "/tmp/honggfuzz_socket.%i", getpid());
+    snprintf(socketPath, sizeof(socketPath), "/tmp/honggfuzz_socket");
+
+    if ((s = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+        perror("socket");
+        return false;
+    }
+
+    local.sun_family = AF_UNIX;
+    strcpy(local.sun_path, socketPath);
+    unlink(local.sun_path);
+    len = strlen(local.sun_path) + sizeof(local.sun_family);
+    if (bind(s, (struct sockaddr *)&local, len) == -1) {
+        perror("bind");
+        return false;
+    }
+
+    if (listen(s, 5) == -1) {
+        perror("listen");
+        return false;
+    }
+
+    printf("Waiting for SocketFuzzer connection on socket: %s\n", socketPath);
+    t = sizeof(remote);
+    if ((run->socketFuzzerData.clientSocket = accept(s, (struct sockaddr *)&remote, &t)) == -1) {
+        perror("accept");
+        return false;
+    }
+
+    run->socketFuzzerData.serverSocket = s;
+    printf("A SocketFuzzer client connected. Continuing.\n");
+
+    return true;
+}
+
+void cleanupSocketFuzzer() {
+    char socketPath[512];
+    //snprintf(socketPath, sizeof(socketPath), "/tmp/honggfuzz_socket.%i", getpid());
+    snprintf(socketPath, sizeof(socketPath), "/tmp/honggfuzz_socket");
+    unlink(socketPath);
+}

--- a/socketfuzzer.h
+++ b/socketfuzzer.h
@@ -1,0 +1,12 @@
+#include "honggfuzz.h"
+
+bool fuzz_waitForExternalInput(run_t* run);
+
+bool fuzz_prepareSocketFuzzer(run_t* run);
+int fuzz_waitforSocketFuzzer(run_t* run);
+
+bool fuzz_notifySocketFuzzerNewCov(honggfuzz_t *hfuzz);
+bool fuzz_notifySocketFuzzerCrash(run_t* run);
+
+bool setupSocketFuzzer(honggfuzz_t *hfuzz);
+void cleanupSocketFuzzer();

--- a/socketfuzzer/Makefile
+++ b/socketfuzzer/Makefile
@@ -1,0 +1,5 @@
+all: vulnserver_cov
+
+vulnserver_cov:
+	unset HFUZZ_CC_ASAN
+	../hfuzz_cc/hfuzz-gcc vulnserver_cov.c -o vulnserver_cov

--- a/socketfuzzer/README.md
+++ b/socketfuzzer/README.md
@@ -1,0 +1,126 @@
+# Honggfuzz - SocketClient
+
+Implement an external fuzzer to fuzz network servers or similar.
+
+Tested on Ubuntu 17.04.
+
+
+## Protocol
+
+Simple:
+
+```
+HonggFuzz      <->       FFW
+             "Fuzz" -->
+         <-- "Okay"
+             "New!" -->
+             "Cras" -->
+         <-- "bad!"
+```
+
+* "Fuzz": HongFuzz tells FFW to send its network messages to the target server
+* "Okay": FFW tells HonggFuzz that it is finished sending the messages
+* "New!": HonggFuzz tells FFW that new basic blocks have been reached
+* "Cras": HonggFuzz tells FFW that the target has crashed
+* "bad!": FFW tells Honggfuzz that the server is crashed
+
+## Overview
+
+`vulnserver_cov` will listen to localhost:5001 and expect messages starting with "A", "B", "C",
+"D" or "E". Message "B" can provoke a stack based buffer overflow, while message "C"
+can provoke a heap based buffer overflow.
+
+The current `honggfuzz_socketclient` will send one of these messages (decided by the user),
+after honggfuzz told it that it is ready (the client process is started). Number 0-4 correspond
+to "A"-"E", while number 5 and 6 will provoke memory corruption overflows.
+
+`honggfuzz_socketclient` will then proceed to send the messages to `vulnserver_cov` on port
+5001. After that hongfuzz may send a message to `hongfuzz_client`, indicating that new
+basic blocks have been reached.
+
+
+## Preparation
+
+Compile the test server, with `make` or:
+```
+~/honggfuzz/hfuzz_cc/hfuzz-gcc vulnserver_cov.c -O0 -o vulnserver_cov
+```
+
+## How-to
+
+Start hongfuzz in socket-client mode:
+
+```
+$ cd ~/honggfuzz
+$ mkdir test
+$ cd test
+$ ../honggfuzz --keep_output --debug --sanitizers --sancov --stdin_input --threads 1 --verbose --logfile log.txt --socket_fuzzer -- ../socketfuzzer/vulnserver_cov
+Waiting for SocketFuzzer connection on socket: /tmp/honggfuzz_socket.<pid>
+```
+
+In another terminal, start the socketfuzzer client:
+```
+$ python ./honggfuzz_socketclient.py interactive
+connecting to /tmp/honggfuzz_socket
+--[ Send Msg #: 1
+Send to target: 1
+--[ R Adding file to corpus...
+--[ Send Msg #: 5
+Send to target: 5
+--[ R Target crashed
+--[ Send Msg #: 1
+Send to target: 1
+--[ Send Msg #: 5
+Send to target: 5
+--[ Send Msg #: 1
+Send to target: 1
+--[ Send Msg #: 5
+Send to target: 5
+--[ Send Msg #: 2
+Send to target: 2
+--[ R Adding file to corpus...
+--[ Send Msg #: 3
+Send to target: 3
+--[ R Adding file to corpus...
+--[ Send Msg #: 5
+Send to target: 5
+```
+
+Automatic test, successful run:
+```
+$ ./unittest.sh
+Auto
+connecting to /tmp/honggfuzz_socket
+
+Test: 0 - initial
+  ok: Fuzz
+
+Test: 1 - first new BB
+  ok: New!
+  ok: Fuzz
+
+Test: 2 - second new BB
+  ok: New!
+  ok: Fuzz
+
+Test: 3 - repeat second msg, no new BB
+  ok: Fuzz
+
+Test: 4 - crash stack
+  ok: Cras
+  ok: Fuzz
+
+Test: 5 - resend second, no new BB
+  ok: Fuzz
+
+Test: 6 - send three, new BB
+  ok: New!
+  ok: Fuzz
+
+Test: 7 - send four, new BB
+  ok: New!
+  ok: Fuzz
+
+Test: 8 - send four again, no new BB
+  ok: Fuzz
+```

--- a/socketfuzzer/honggfuzz_socketclient.py
+++ b/socketfuzzer/honggfuzz_socketclient.py
@@ -1,0 +1,317 @@
+#!/usr/bin/python
+# Python3
+
+import socket
+import sys
+import time
+import random
+
+
+class HonggfuzzSocket:
+    def __init__(self):
+        self.sock = None
+
+
+    def connect(self, file):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        server_address = file
+        print( 'connecting to %s' % server_address)
+
+        try:
+            self.sock.connect(server_address)
+        except socket.error as msg:
+            print ("Error connecting to honggfuzz socket: " + str(msg))
+            sys.exit(1)
+
+
+    def send(self, data):
+        self.sock.sendall( str.encode(data) )
+
+
+    def recv(self):
+        return self.sock.recv(4).decode()
+
+
+    def disconnect(self):
+        self.sock.close()
+
+
+class TargetSocket:
+    def __init__(self):
+        self.sock = None
+
+    def testServerConnectionTcp(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_address = ('localhost', self.targetPort)
+
+        try:
+            sock.connect(server_address)
+        except socket.error as exc:
+            return False
+
+        sock.close()
+
+        return True
+
+
+    def sendToSocket(self, data):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+
+        host = 'localhost'
+        port = 5001
+
+        isOpen = False
+
+        n = 0
+        while isOpen is False:
+            try:
+                s.connect((host, port))
+                isOpen = True
+            except Exception as e:
+                time.sleep(0.1)
+                n += 1
+                isOpen = False
+
+            if n == 10:
+                return False
+
+        try:
+            s.send( str.encode(data) )
+        except Exception as e:
+            print( "B: " + str(e))
+
+        s.close()
+        return True
+
+
+    def sendFuzz(self, n):
+        data = ""
+        if n == 1:
+            data = "AAAAAA"
+        if n == 2:
+            data = "BBBBBB"
+        if n == 3:
+            data = "CCCCCC"
+        if n == 4:
+            data = "DDDDDD"
+        if n == 5:
+            data = "EEEEEE"
+        if n == 6:
+            # stack buffer overflow
+            data = "B" * 128
+        if n == 7:
+            # heap buffer overflow
+            data = "C" * 128
+
+        #print "  Send: " + str(data)
+        return self.sendToSocket(data)
+
+
+
+def sendResp(targetSocketRes, hfSocket):
+    if not targetSocketRes:
+        print "  ! Server down. Send: bad!"
+        hfSocket.send("bad!")
+    else:
+        hfSocket.send("okay")
+
+
+
+def auto():
+    print "Auto"
+
+    hfSocket = HonggfuzzSocket()
+    targetSocket = TargetSocket()
+
+    hfSocket.connect("/tmp/honggfuzz_socket")
+
+
+    print ""
+    print "Test: 0 - initial"
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+
+    print ""
+    print "Test: 1 - first new BB"
+    ret = targetSocket.sendFuzz(1)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "New!" or ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+
+    print ""
+    print "Test: 2 - second new BB"
+    targetSocket.sendFuzz(2)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "New!":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+
+    print ""
+    print "Test: 3 - repeat second msg, no new BB"
+    targetSocket.sendFuzz(2)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+    print ""
+    print "Test: 4 - crash stack"
+    targetSocket.sendFuzz(6)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "Cras":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+    print ""
+    print "Test: 5 - resend second, no new BB"
+    targetSocket.sendFuzz(2)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+    print ""
+    print "Test: 6 - send three, new BB"
+    targetSocket.sendFuzz(3)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "New!":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+
+    print ""
+    print "Test: 7 - send four, new BB"
+    targetSocket.sendFuzz(4)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "New!":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+
+    print ""
+    print "Test: 8 - send four again, no new BB"
+    targetSocket.sendFuzz(4)
+    sendResp(ret, hfSocket)
+    ret = hfSocket.recv()
+    if ret == "Fuzz":
+        print "  ok: " + ret
+    else:
+        print "  nok: " + ret
+        return
+
+
+def interactive():
+    hfSocket = HonggfuzzSocket()
+    targetSocket = TargetSocket()
+
+    hfSocket.connect("/tmp/honggfuzz_socket")
+
+    while(True):
+        try:
+            recv = hfSocket.recv()
+
+            if recv == "Fuzz":
+                # Send the bad data to the target
+                i = input("--[ Send Msg #: ")
+                #i = random.randint(0, 3)
+                #sendFuzz(int(i))
+                print "Send to target: " + str(i)
+                if not targetSocket.sendFuzz(i):
+                    print "Server down. Send: bad!"
+                    hfSocket.send("bad!")
+                else:
+                    hfSocket.send("okay")
+
+            elif recv == "New!":
+                print ("--[ R Adding file to corpus...")
+                # add the data you sent to the target to your input
+                # corpus, as it reached new basic blocks
+
+            elif recv == "Cras":
+                print ("--[ R Target crashed")
+                # target crashed, store the things you sent to the target
+
+            elif recv == "":
+                print("Hongfuzz quit, exiting too\n")
+                break
+
+            else:
+                print ("--[ Unknown: " + str(recv))
+
+        except Exception as e:
+            print("Exception: " + str(e))
+
+
+
+def main():
+    if len(sys.argv) == 2:
+        if sys.argv[1] == "auto":
+            auto()
+        elif sys.argv[1] == "interactive":
+            interactive()
+    else:
+        print "honggfuzz_socketclient.py [auto/interactive]"
+
+
+main()

--- a/socketfuzzer/unittest.sh
+++ b/socketfuzzer/unittest.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+rm -rf HF_SANCOV/ HONGGFUZZ.REPORT.TXT SIGABR* HF.san*
+
+../honggfuzz --keep_output --debug --sanitizers --sancov --stdin_input --threads 1 --verbose --logfile log.txt --socket_fuzzer -- ./vulnserver_cov &
+
+python ./honggfuzz_socketclient.py auto

--- a/socketfuzzer/vulnserver_cov.c
+++ b/socketfuzzer/vulnserver_cov.c
@@ -1,0 +1,136 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <unistd.h>
+#include <crypt.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+
+/* Do nothing with first message */
+void handleData0(char *data, int len) {
+    printf("Auth success\n");
+}
+
+/* Second message is stack based buffer overflow */
+void handleData1(char *data, int len) {
+    char buff[8];
+    bzero(buff, 8);
+    memcpy(buff, data, len);
+    printf("Handledata1: %s\n", buff);
+}
+
+/* Third message is heap overflow */
+void handleData2(char *data, int len) {
+    char *buff = malloc(8);
+    bzero(buff, 8);
+    memcpy(buff, data, len);
+    printf("Handledata2: %s\n", buff);
+    free(buff);
+}
+
+void handleData3(char *data, int len) {
+    printf("Meh: %i\n", len);
+}
+
+void handleData4(char *data, int len) {
+    printf("Blah: %i\n", len);
+}
+
+void doprocessing (int sock) {
+	char data[1024];
+	int n = 0;
+    int len = 0;
+
+    while(1) {
+    	bzero(data, sizeof(data));
+    	len = read(sock, data, 1024);
+
+        if(len == 0 || len <= 1) {
+            return;
+        }
+
+        printf("Received data with len: %i on state: %i\n", len, n);
+        switch( data[0]  ) {
+            case 'A':
+                handleData0(data, len);
+                write(sock, "ok", 2);
+                break;
+            case 'B':
+                handleData1(data, len);
+                write(sock, "ok", 2);
+                break;
+            case 'C':
+                handleData2(data, len);
+                write(sock, "ok", 2);
+                break;
+            case 'D':
+                handleData3(data, len);
+                write(sock, "ok", 2);
+                break;
+            case 'E':
+                handleData4(data, len);
+                write(sock, "ok", 2);
+                break;
+            default:
+                return;
+        }
+
+        n++;
+    }
+}
+
+
+int main( int argc, char *argv[] ) {
+    int sockfd, newsockfd, portno, clilen;
+    char buffer[256];
+    struct sockaddr_in serv_addr, cli_addr;
+    int n, pid;
+
+    if(argc == 2) {
+        portno = atoi(argv[1]);
+    } else {
+        portno = 5001;
+    }
+
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+      perror("ERROR opening socket");
+      exit(1);
+    }
+
+    int reuse = 1;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, (const char*)&reuse, sizeof(reuse)) < 0)
+        perror("setsockopt(SO_REUSEPORT) failed");
+
+    bzero((char *) &serv_addr, sizeof(serv_addr));
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_addr.s_addr = INADDR_ANY;
+    serv_addr.sin_port = htons(portno);
+
+    printf("Listening on port: %i\n", portno);
+
+    /* Now bind the host address using bind() call.*/
+    if (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
+        perror("ERROR on binding");
+        exit(1);
+    }
+
+    listen(sockfd,5);
+    clilen = sizeof(cli_addr);
+
+    while (1) {
+        newsockfd = accept(sockfd, (struct sockaddr *) &cli_addr, &clilen);
+        if (newsockfd < 0) {
+             perror("ERROR on accept");
+             exit(1);
+        }
+        printf("New client connected\n");
+        doprocessing(newsockfd);
+        printf("Closing...\n");
+        shutdown(newsockfd, 2);
+        close(newsockfd);
+    }
+}


### PR DESCRIPTION
Aka The FFW honggfuzz patch.

This proposed patch for honggfuzz is used by the fuzzing for worms (FFW) framework available here: github.com/dobin/ffw
This patch makes it possible to use honggfuzz as a code coverage tool for long-living (network-) servers.

It provides the following functionality:
* A socket interface for an external fuzzer
* Support for code coverage of long living processes

The socket interface supports the following messages:
* Honggfuzz -> Fuzzer: "Fuzz": Send fuzz data to target
* Honggfuzz -> Fuzzer: "Cras": Target crashed
* Honggfuzz -> Fuzzer: "New!": New basic block reached
* Fuzzer -> Honggfuzz: "okay": Fuzzer sent his stuff to target
* Fuzzer -> Honggfuzz: "bad!": The server is unreachable

Honggfuzz will implement the following tasks:
* Start the target
* Restart the target if it crashes
* Restart the target if a crash/hang is detected by the fuzzer
* Provide code coverage information about new basic blocks

An example vulnerable server plus tests have been provided in the
`socketfuzzer/` directory.