### PR TITLE
WIP: port persistent fuzzing to macOS

### DIFF
--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -88,7 +88,7 @@ static void setupRLimits(void) {
         LOG_E("RLIMIT_NOFILE max limit < 1024 (%u). Expect troubles!", (unsigned int)rlim.rlim_max);
         return;
     }
-    rlim.rlim_cur = 1024; // we don't need more and there is no easy and portable way to know the limit
+    rlim.rlim_cur = MIN(1024, rlim.rlim_max); // we don't need more
     if (setrlimit(RLIMIT_NOFILE, &rlim) == -1) {
         PLOG_E("Couldn't setrlimit(RLIMIT_NOFILE, cur=max=%u)", (unsigned int)rlim.rlim_max);
     }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -88,7 +88,7 @@ static void setupRLimits(void) {
         LOG_E("RLIMIT_NOFILE max limit < 1024 (%u). Expect troubles!", (unsigned int)rlim.rlim_max);
         return;
     }
-    rlim.rlim_cur = rlim.rlim_max;
+    rlim.rlim_cur = 1024; // we don't need more and there is no easy and portable way to know the limit
     if (setrlimit(RLIMIT_NOFILE, &rlim) == -1) {
         PLOG_E("Couldn't setrlimit(RLIMIT_NOFILE, cur=max=%u)", (unsigned int)rlim.rlim_max);
     }


### PR DESCRIPTION
This is very basic and hfuzz-cc doesn't work yet but it's enough to make honggfuzz-rs work.

About the setrlimit patch, I choose a very basic solution which is maybe not the best.
The recommended way to set NOFILE to the maximum on macOS is to set it to `MIN(OPEN_MAX, rlim_max)` but `OPEN_MAX` is deprecated and undefined on Linux. There is also `FOPEN_MAX` but it is usually set to a very low value: 16 (the minimum guaranteed value by Posix). I also tried other solution but none of them were satisfactory and portable.
But anyway, in our case, we only need a limit of 1024 (here is my evidence: https://github.com/google/honggfuzz/blob/master/honggfuzz.c#L86) so I choose the easy solution to set the limit this value directly.

About arch_reapChild, since the old version contained no specific macOS logic, I copied to code from the posix version and it works well.

The project now works with Rust code but `hfuzz-cc` fails to compile C/C++ code.
Here is the error I get on High Sierra:
```
paulg@Pauls-iMac ~/Projects> ./honggfuzz/hfuzz_cc/hfuzz-cc -v test.c 
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin17.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" -cc1 -triple x86_64-apple-macosx10.13.0 -Wdeprecated-objc-isa-usage -Werror=deprecated-objc-isa-usage -emit-obj -mrelax-all -disable-free -disable-llvm-verifier -discard-value-names -main-file-name test.c -mrelocation-model pic -pic-level 2 -mthread-model posix -mdisable-fp-elim -fno-strict-return -masm-verbose -munwind-tables -target-cpu penryn -target-linker-version 305 -v -dwarf-column-info -debugger-tuning=lldb -resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -I /Users/paulg/Projects/honggfuzz/includes/ -D __NO_STRING_INLINES -D "HFND_FUZZING_ENTRY_FUNCTION_CXX(x,y)=extern \"C\" int HonggfuzzNetDriver_main(x,y);extern const char* LIBHFNETDRIVER_module_netdriver;const char** LIBHFNETDRIVER_module_main = &LIBHFNETDRIVER_module_netdriver;int HonggfuzzNetDriver_main(x,y)" -D HFND_FUZZING_ENTRY_FUNCTION(x,y)=int HonggfuzzNetDriver_main(x,y);extern const char* LIBHFNETDRIVER_module_netdriver;const char** LIBHFNETDRIVER_module_main = &LIBHFNETDRIVER_module_netdriver;int HonggfuzzNetDriver_main(x,y) -I/usr/local/include -Wno-unused-command-line-argument -fdebug-compilation-dir /Users/paulg/Projects -ferror-limit 19 -fmessage-length 127 -fsanitize-coverage-type=3 -fsanitize-coverage-indirect-calls -fsanitize-coverage-trace-cmp -fsanitize-coverage-trace-pc-guard -stack-protector 1 -fno-builtin -fblocks -fno-inline -fobjc-runtime=macosx-10.13.0 -fencode-extended-block-signature -fmax-type-align=16 -fdiagnostics-show-option -fcolor-diagnostics -mllvm -sanitizer-coverage-prune-blocks=0 -mllvm -sanitizer-coverage-level=3 -o /var/folders/zb/762prdl976b40gl56_np9kbw0000gn/T/test-ffd9d0.o -x c test.c
clang -cc1 version 9.0.0 (clang-900.0.39.2) default target x86_64-apple-darwin17.4.0
ignoring nonexistent directory "/usr/local/include"
ignoring nonexistent directory "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/local/include"
ignoring nonexistent directory "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/Library/Frameworks"
#include "..." search starts here:
#include <...> search starts here:
 /Users/paulg/Projects/honggfuzz/includes
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include
 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks (framework directory)
End of search list.
test.c:18:2: warning: implicit declaration of function 'abort' is invalid in C99 [-Wimplicit-function-declaration]
        abort();
        ^
1 warning generated.
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld" -demangle -lto_library /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libLTO.dylib -no_deduplicate -dynamic -arch x86_64 -macosx_version_min 10.13.0 -syslibroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -o a.out /var/folders/zb/762prdl976b40gl56_np9kbw0000gn/T/test-ffd9d0.o /tmp/libhfnetdriver.501.ecd73e8360793610.a /tmp/libhfuzz.501.6e8984ed8b84ad11.a /tmp/libhfnetdriver.501.ecd73e8360793610.a -u LIBHFNETDRIVER_module_main -u LIBHFUZZ_module_instrument -u LIBHFUZZ_module_memorycmp -lpthread -L/usr/local/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0/lib/darwin/libclang_rt.ubsan_osx_dynamic.dylib -rpath @executable_path -rpath /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0/lib/darwin -lSystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0/lib/darwin/libclang_rt.osx.a
Undefined symbols for architecture x86_64:
  "LIBHFNETDRIVER_module_main", referenced from:
     -u command line option
  "LIBHFUZZ_module_instrument", referenced from:
     -u command line option
     (maybe you meant: _LIBHFUZZ_module_instrument)
  "LIBHFUZZ_module_memorycmp", referenced from:
     -u command line option
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```