### PR TITLE
Makefile: On Windows Subsystem for Linux (WSL), build as Posix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,9 @@ GREP_COLOR ?=
 
 OS ?= $(shell uname -s)
 MARCH ?= $(shell uname -m)
+KERNEL ?= $(shell uname -r)
 
-ifeq ($(OS),Linux)
+ifeq ($(OS)$(findstring Microsoft,$(KERNEL)),Linux)
     ARCH := LINUX
 
     ARCH_CFLAGS := -std=c11 -I/usr/local/include \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ OS ?= $(shell uname -s)
 MARCH ?= $(shell uname -m)
 KERNEL ?= $(shell uname -r)
 
-ifeq ($(OS)$(findstring Microsoft,$(KERNEL)),Linux)
+ifeq ($(OS)$(findstring Microsoft,$(KERNEL)),Linux) # matches Linux but excludes WSL (Windows Subsystem for Linux)
     ARCH := LINUX
 
     ARCH_CFLAGS := -std=c11 -I/usr/local/include \


### PR DESCRIPTION
The Linux specific parts of honggfuzz are too specific to work on WSL but the Posix version works well.
This change uses the internet "de facto" way of detecting WSL (ie: `uname -r`) to condition the compilation.