### PR TITLE
fix formatstring as it makes honggfuzz crash

### DIFF
--- a/linux/trace.c
+++ b/linux/trace.c
@@ -1101,7 +1101,7 @@ static void arch_traceExitSaveData(run_t* run, pid_t pid) {
 
     /* Generate report */
     run->report[0] = '\0';
-    util_ssnprintf(run->report, sizeof(run->report), "EXIT_CODE: %s\n", HF_SAN_EXIT_CODE);
+    util_ssnprintf(run->report, sizeof(run->report), "EXIT_CODE: %i\n", HF_SAN_EXIT_CODE);
     util_ssnprintf(run->report, sizeof(run->report), "ORIG_FNAME: %s\n", run->origFileName);
     util_ssnprintf(run->report, sizeof(run->report), "FUZZ_FNAME: %s\n", run->crashFileName);
     util_ssnprintf(run->report, sizeof(run->report), "PID: %d\n", pid);


### PR DESCRIPTION
fix for:
```

(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:93
#1  0x00007f99322098c5 in _IO_vfprintf_internal (s=s@entry=0x7f992e9448d0, format=<optimized out>, 
    format@entry=0x557f4d88d82a "EXIT_CODE: %s\n", ap=ap@entry=0x7f992e944aa0) at vfprintf.c:1643
#2  0x00007f9932234440 in _IO_vsnprintf (string=0x7f992e948d04 "EXIT_CODE: ", maxlen=<optimized out>, 
    format=0x557f4d88d82a "EXIT_CODE: %s\n", args=0x7f992e944aa0) at vsnprintf.c:114
#3  0x0000557f4d885fac in util_vssnprintf (str=0x7f992e948d04 "EXIT_CODE: ", size=8192, format=0x557f4d88d82a "EXIT_CODE: %s\n", 
    ap=0x7f992e944aa0) at libhfcommon/util.c:153
#4  0x0000557f4d886058 in util_ssnprintf (str=0x7f992e948d04 "EXIT_CODE: ", size=8192, format=0x557f4d88d82a "EXIT_CODE: %s\n")
    at libhfcommon/util.c:159
#5  0x0000557f4d881d59 in arch_traceExitSaveData (run=0x7f992e946cd0, pid=11757) at linux/trace.c:1107
#6  0x0000557f4d88216e in arch_traceExitAnalyze (run=0x7f992e946cd0, pid=11757) at linux/trace.c:1163
#7  0x0000557f4d87d1e1 in arch_reapChild (run=0x7f992e946cd0) at linux/arch.c:368
#8  0x0000557f4d87b8a9 in subproc_Run (run=0x7f992e946cd0) at subproc.c:342
#9  0x0000557f4d873b22 in fuzz_fuzzLoopSocket (run=0x7f992e946cd0) at fuzz.c:488
#10 0x0000557f4d873fd7 in fuzz_threadNew (arg=0x557f4dad7fa0 <hfuzz>) at fuzz.c:574
#11 0x00007f99330a87fc in start_thread (arg=0x7f992e94b700) at pthread_create.c:465
#12 0x00007f99322c8b5f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
