### PR TITLE
Fix compatibility issues with NetBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ else
                    -Wextra -Wno-initializer-overrides -Wno-override-init \
                    -Wno-unknown-warning-option -Wno-unknown-pragmas \
                    -funroll-loops
-    ARCH_LDFLAGS := -lpthread -L/usr/local/lib
+    ARCH_LDFLAGS := -pthread -L/usr/local/lib
     # OS Posix
 endif
 
@@ -440,3 +440,15 @@ mac/arch.o: sancov.h subproc.h
 posix/arch.o: arch.h honggfuzz.h libhfcommon/util.h fuzz.h
 posix/arch.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 posix/arch.o: libhfcommon/log.h sancov.h subproc.h
+
+PREFIX		?= /usr/local
+BIN_PATH	=$(PREFIX)/bin
+
+install: all
+	mkdir -p -m 755 $${DESTDIR}$(BIN_PATH)
+	install -m 755 honggfuzz $${DESTDIR}$(BIN_PATH)
+	install -m 755 hfuzz_cc/hfuzz-cc $${DESTDIR}$(BIN_PATH)
+	install -m 755 hfuzz_cc/hfuzz-clang $${DESTDIR}$(BIN_PATH)
+	install -m 755 hfuzz_cc/hfuzz-clang++ $${DESTDIR}$(BIN_PATH)
+	install -m 755 hfuzz_cc/hfuzz-gcc $${DESTDIR}$(BIN_PATH)
+	install -m 755 hfuzz_cc/hfuzz-g++ $${DESTDIR}$(BIN_PATH)

--- a/libhfcommon/util.c
+++ b/libhfcommon/util.c
@@ -284,11 +284,11 @@ int64_t fastArray64Search(uint64_t* array, size_t arraySz, uint64_t key) {
 }
 
 bool util_isANumber(const char* s) {
-    if (!isdigit(s[0])) {
+    if (!isdigit((unsigned char)s[0])) {
         return false;
     }
     for (int i = 0; s[i]; s++) {
-        if (!isdigit(s[i]) && s[i] != 'x') {
+        if (!isdigit((unsigned char)s[i]) && s[i] != 'x') {
             return false;
         }
     }

--- a/libhfuzz/memorycmp.c
+++ b/libhfuzz/memorycmp.c
@@ -44,14 +44,14 @@ static inline int _strcasecmp(const char* s1, const char* s2, uintptr_t addr) {
     unsigned int v = 0;
 
     size_t i;
-    for (i = 0; tolower(s1[i]) == tolower(s2[i]); i++) {
+    for (i = 0; tolower((unsigned char)s1[i]) == tolower((unsigned char)s2[i]); i++) {
         if (s1[i] == '\0' || s2[i] == '\0') {
             break;
         }
         v++;
     }
     instrumentUpdateCmpMap(addr, v);
-    return (tolower(s1[i]) - tolower(s2[i]));
+    return (tolower((unsigned char)s1[i]) - tolower((unsigned char)s2[i]));
 }
 
 static inline int _strncmp(const char* s1, const char* s2, size_t n, uintptr_t addr) {
@@ -86,8 +86,8 @@ static inline int _strncasecmp(const char* s1, const char* s2, size_t n, uintptr
     int ret = 0;
 
     for (size_t i = 0; i < n; i++) {
-        if (tolower(s1[i]) != tolower(s2[i])) {
-            ret = ret ? ret : (tolower(s1[i]) - tolower(s2[i]));
+        if (tolower((unsigned char)s1[i]) != tolower((unsigned char)s2[i])) {
+            ret = ret ? ret : (tolower((unsigned char)s1[i]) - tolower((unsigned char)s2[i]));
         } else {
             v++;
         }


### PR DESCRIPTION
1. Using -pthread instead of -lpthread flag
2. Add install option for make
3. Convert char type to unsigned char type before calling isdigit(3)
and tolower(3). Because according to the ctype(3) man page of NetBSD,
the parameter of these functions should be representable as unsigned
char to avoid undefined behaviors. For more details, please refer to:
http://netbsd.gw.com/cgi-bin/man-cgi?ctype+3+NetBSD-current