### PR TITLE
Add "only-printable" Fuzzing Mode

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -308,6 +308,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
 #else
                 .monitorSIGABRT = true,
 #endif
+                .only_printable = false,
             },
         .sanitizer =
             {
@@ -432,6 +433,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "no_fb_timeout", required_argument, NULL, 0x106 }, "Skip feedback if the process has timeouted (default: false)" },
         { { "exit_upon_crash", no_argument, NULL, 0x107 }, "Exit upon seeing the first crash (default: false)" },
         { { "socket_fuzzer", no_argument, NULL, 0x10b }, "Instrument external fuzzer via socket" },
+        { { "only_printable", no_argument, NULL, 'o' }, "Only generate printable inputs" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blacklist filter file (one entry per line)" },
@@ -464,7 +466,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
     int opt_index = 0;
     for (;;) {
         int c = getopt_long(
-            argc, argv, "-?hQvVsuPxf:dqe:W:r:c:F:t:R:n:N:l:p:g:E:w:B:CzTS", opts, &opt_index);
+            argc, argv, "-?hQvVsuPxf:dqe:W:r:c:F:t:R:n:N:l:p:g:E:w:B:CzTSo", opts, &opt_index);
         if (c < 0) break;
 
         switch (c) {
@@ -538,6 +540,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
             case 0x10B:
                 hfuzz->socketFuzzer.enabled = true;
                 hfuzz->timing.tmOut = 0;  // Disable process timeout checks
+                break;
+            case 'o':
+                hfuzz->cfg.only_printable = true;
                 break;
             case 'z':
                 hfuzz->feedback.dynFileMethod |= _HF_DYNFILE_SOFT;

--- a/fuzz.c
+++ b/fuzz.c
@@ -621,6 +621,8 @@ void fuzz_threadsStart(honggfuzz_t* hfuzz, pthread_t* threads) {
         LOG_F("Couldn't prepare sancov options");
     }
 
+    mangle_init(hfuzz->cfg.only_printable);
+
     if (hfuzz->socketFuzzer.enabled) {
         /* Don't do dry run with socketFuzzer */
         LOG_I("Entering phase - Feedback Driven Mode (SocketFuzzer)");

--- a/fuzz.c
+++ b/fuzz.c
@@ -173,7 +173,8 @@ static void fuzz_setDynamicMainState(run_t* run) {
      * dynamic corpus, so the dynamic phase doesn't fail because of lack of useful inputs
      */
     if (run->global->io.dynfileqCnt == 0) {
-        fuzz_addFileToFileQ(run->global, (const uint8_t*)"\0", 1U);
+        const char *single_byte = run->global->cfg.only_printable ? " " : "\0";
+        fuzz_addFileToFileQ(run->global, (const uint8_t*)single_byte, 1U);
     }
 }
 

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -243,6 +243,7 @@ typedef struct {
         pthread_mutex_t report_mutex;
         bool monitorSIGABRT;
         size_t dynFileIterExpire;
+        bool only_printable;
     } cfg;
     struct {
         bool enable;

--- a/input.c
+++ b/input.c
@@ -56,7 +56,11 @@ void input_setSize(run_t* run, size_t sz) {
     if (sz > run->global->mutate.maxFileSz) {
         PLOG_F("Too large size requested: %zu > maxSize: %zu", sz, run->global->mutate.maxFileSz);
     }
+    size_t old_sz = run->dynamicFileSz;
     run->dynamicFileSz = sz;
+    if (run->global->cfg.only_printable && old_sz < sz) {
+        memset(run->dynamicFile, ' ', sz - old_sz);
+    }
 }
 
 static bool input_getDirStatsAndRewind(honggfuzz_t* hfuzz) {

--- a/libhfcommon/util.c
+++ b/libhfcommon/util.c
@@ -145,6 +145,12 @@ void util_turnToPrintable(uint8_t* buf, size_t sz) {
     }
 }
 
+void util_rndBufPrintable(uint8_t* buf, size_t sz) {
+    for (size_t i = 0; i < sz; i++) {
+        buf[i] = util_rndPrintable();
+    }
+}
+
 void util_rndBuf(uint8_t* buf, size_t sz) {
     pthread_once(&rndThreadOnce, util_rndInitThread);
     if (sz == 0) {

--- a/libhfcommon/util.c
+++ b/libhfcommon/util.c
@@ -133,6 +133,18 @@ uint64_t util_rndGet(uint64_t min, uint64_t max) {
     return ((util_rnd64() % (max - min + 1)) + min);
 }
 
+/* Generate random printable ASCII */
+uint8_t util_rndPrintable(void) {
+    return util_rndGet(32, 126);
+}
+
+/* Turn one byte to a printable ASCII */
+void util_turnToPrintable(uint8_t* buf, size_t sz) {
+    for (size_t i = 0; i < sz; i++)  {
+        buf[i] = buf[i] % 95 + 32;
+    }
+}
+
 void util_rndBuf(uint8_t* buf, size_t sz) {
     pthread_once(&rndThreadOnce, util_rndInitThread);
     if (sz == 0) {

--- a/libhfcommon/util.h
+++ b/libhfcommon/util.h
@@ -87,6 +87,8 @@ extern uint64_t util_rndGet(uint64_t min, uint64_t max);
 
 extern void util_rndBuf(uint8_t* buf, size_t sz);
 
+extern void util_rndBufPrintable(uint8_t* buf, size_t sz);
+
 extern uint64_t util_rnd64(void);
 
 extern uint8_t util_rndPrintable(void);

--- a/libhfcommon/util.h
+++ b/libhfcommon/util.h
@@ -89,6 +89,10 @@ extern void util_rndBuf(uint8_t* buf, size_t sz);
 
 extern uint64_t util_rnd64(void);
 
+extern uint8_t util_rndPrintable(void);
+
+extern void util_turnToPrintable(uint8_t* buf, size_t sz);
+
 extern int util_ssnprintf(char* str, size_t size, const char* format, ...)
     __attribute__((format(printf, 3, 4)));
 

--- a/mangle.c
+++ b/mangle.c
@@ -854,18 +854,6 @@ static void mangle_AddSubPrintable(run_t* run) {
     util_turnToPrintable((uint8_t *)&run->dynamicFile[off], varLen);
 }
 
-static void addPrintable(uint8_t *byte) {
-    *byte = ((*byte) - 32 + 1) % 95 + 32;
-}
-
-static void decPrintable(uint8_t *byte) {
-    *byte = ((*byte) - 32 + 94) % 95 + 32;
-}
-
-static void negPrintable(uint8_t *byte) {
-    *byte = 94 - ((*byte) - 32) + 32;
-}
-
 static void mangle_IncByte(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     run->dynamicFile[off] += (uint8_t)1UL;
@@ -873,7 +861,7 @@ static void mangle_IncByte(run_t* run) {
 
 static void mangle_IncBytePrintable(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
-    addPrintable(&run->dynamicFile[off]);
+    run->dynamicFile[off] = (run->dynamicFile[off] - 32 + 1) % 95 + 32;
 }
 
 static void mangle_DecByte(run_t* run) {
@@ -883,7 +871,7 @@ static void mangle_DecByte(run_t* run) {
 
 static void mangle_DecBytePrintable(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
-    decPrintable(&run->dynamicFile[off]);
+    run->dynamicFile[off] = (run->dynamicFile[off] - 32 + 94) % 95 + 32;
 }
 
 static void mangle_NegByte(run_t* run) {
@@ -893,7 +881,7 @@ static void mangle_NegByte(run_t* run) {
 
 static void mangle_NegBytePrintable(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
-    negPrintable(&run->dynamicFile[off]);
+    run->dynamicFile[off] = 94 - (run->dynamicFile[off] - 32) + 32;
 }
 
 static void mangle_CloneByte(run_t* run) {

--- a/mangle.c
+++ b/mangle.c
@@ -129,7 +129,7 @@ static void mangle_BitPrintable(run_t* run) {
     util_turnToPrintable(&(run->dynamicFile[off]), 1);
 }
 
-static void mangle_DictionaryInsertNoCheck(run_t *run) {
+static void mangle_DictionaryInsertNoCheck(run_t* run) {
     uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
     struct strings_t* str = TAILQ_FIRST(&run->global->mutate.dictq);
     for (uint64_t i = 0; i < choice; i++) {
@@ -158,12 +158,7 @@ static void mangle_DictionaryInsertPrintable(run_t* run) {
     mangle_DictionaryInsertNoCheck(run);
 }
 
-static void mangle_Dictionary(run_t* run) {
-    if (run->global->mutate.dictionaryCnt == 0) {
-        mangle_Bit(run);
-        return;
-    }
-
+static void mangle_DictionaryNoCheck(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
 
     uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
@@ -173,7 +168,15 @@ static void mangle_Dictionary(run_t* run) {
     }
 
     mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
-    /* FIXME */
+}
+
+static void mangle_Dictionary(run_t* run) {
+    if (run->global->mutate.dictionaryCnt == 0) {
+        mangle_Bit(run);
+        return;
+    }
+
+    mangle_DictionaryNoCheck(run);
 }
 
 static void mangle_DictionaryPrintable(run_t* run) {
@@ -182,16 +185,7 @@ static void mangle_DictionaryPrintable(run_t* run) {
         return;
     }
 
-    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
-
-    uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
-    struct strings_t* str = TAILQ_FIRST(&run->global->mutate.dictq);
-    for (uint64_t i = 0; i < choice; i++) {
-        str = TAILQ_NEXT(str, pointers);
-    }
-
-    mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
-    /* FIXME */
+    mangle_DictionaryNoCheck(run);
 }
 
 static void mangle_Magic(run_t* run) {

--- a/mangle.c
+++ b/mangle.c
@@ -129,12 +129,7 @@ static void mangle_BitPrintable(run_t* run) {
     util_turnToPrintable(&(run->dynamicFile[off]), 1);
 }
 
-static void mangle_DictionaryInsert(run_t* run) {
-    if (run->global->mutate.dictionaryCnt == 0) {
-        mangle_Bit(run);
-        return;
-    }
-
+static void mangle_DictionaryInsertNoCheck(run_t *run) {
     uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
     struct strings_t* str = TAILQ_FIRST(&run->global->mutate.dictq);
     for (uint64_t i = 0; i < choice; i++) {
@@ -147,22 +142,20 @@ static void mangle_DictionaryInsert(run_t* run) {
     mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
 }
 
+static void mangle_DictionaryInsert(run_t* run) {
+    if (run->global->mutate.dictionaryCnt == 0) {
+        mangle_Bit(run);
+        return;
+    }
+    mangle_DictionaryInsertNoCheck(run);
+}
+
 static void mangle_DictionaryInsertPrintable(run_t* run) {
     if (run->global->mutate.dictionaryCnt == 0) {
         mangle_BitPrintable(run);
         return;
     }
-
-    uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
-    struct strings_t* str = TAILQ_FIRST(&run->global->mutate.dictq);
-    for (uint64_t i = 0; i < choice; i++) {
-        str = TAILQ_NEXT(str, pointers);
-    }
-
-    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
-    mangle_Inflate(run, off, str->len);
-    mangle_Move(run, off, off + str->len, str->len);
-    mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
+    mangle_DictionaryInsertNoCheck(run);
 }
 
 static void mangle_Dictionary(run_t* run) {

--- a/mangle.c
+++ b/mangle.c
@@ -94,9 +94,24 @@ static void mangle_Byte(run_t* run) {
     run->dynamicFile[off] = (uint8_t)util_rnd64();
 }
 
+static void mangle_PrintableByte(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    run->dynamicFile[off] = util_rndPrintable();
+}
+
 static void mangle_Bytes(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     uint32_t val = (uint32_t)util_rnd64();
+
+    /* Overwrite with random 2,3,4-byte values */
+    size_t toCopy = util_rndGet(2, 4);
+    mangle_Overwrite(run, (uint8_t*)&val, off, toCopy);
+}
+
+static void mangle_PrintableBytes(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    uint32_t val = (uint32_t)util_rnd64();
+    util_turnToPrintable((uint8_t *)&val, sizeof(val));
 
     /* Overwrite with random 2,3,4-byte values */
     size_t toCopy = util_rndGet(2, 4);
@@ -108,9 +123,33 @@ static void mangle_Bit(run_t* run) {
     run->dynamicFile[off] ^= (uint8_t)(1U << util_rndGet(0, 7));
 }
 
+static void mangle_BitPrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    run->dynamicFile[off] ^= (uint8_t)(1U << util_rndGet(0, 7));
+    util_turnToPrintable(&(run->dynamicFile[off]), 1);
+}
+
 static void mangle_DictionaryInsert(run_t* run) {
     if (run->global->mutate.dictionaryCnt == 0) {
         mangle_Bit(run);
+        return;
+    }
+
+    uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
+    struct strings_t* str = TAILQ_FIRST(&run->global->mutate.dictq);
+    for (uint64_t i = 0; i < choice; i++) {
+        str = TAILQ_NEXT(str, pointers);
+    }
+
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    mangle_Inflate(run, off, str->len);
+    mangle_Move(run, off, off + str->len, str->len);
+    mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
+}
+
+static void mangle_DictionaryInsertPrintable(run_t* run) {
+    if (run->global->mutate.dictionaryCnt == 0) {
+        mangle_BitPrintable(run);
         return;
     }
 
@@ -141,6 +180,25 @@ static void mangle_Dictionary(run_t* run) {
     }
 
     mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
+    /* FIXME */
+}
+
+static void mangle_DictionaryPrintable(run_t* run) {
+    if (run->global->mutate.dictionaryCnt == 0) {
+        mangle_BitPrintable(run);
+        return;
+    }
+
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+
+    uint64_t choice = util_rndGet(0, run->global->mutate.dictionaryCnt - 1);
+    struct strings_t* str = TAILQ_FIRST(&run->global->mutate.dictq);
+    for (uint64_t i = 0; i < choice; i++) {
+        str = TAILQ_NEXT(str, pointers);
+    }
+
+    mangle_Overwrite(run, (uint8_t*)str->s, off, str->len);
+    /* FIXME */
 }
 
 static void mangle_Magic(run_t* run) {
@@ -386,6 +444,250 @@ static void mangle_Magic(run_t* run) {
     mangle_Overwrite(run, mangleMagicVals[choice].val, off, mangleMagicVals[choice].size);
 }
 
+static void mangle_MagicPrintable(run_t* run) {
+    static const struct {
+        const uint8_t val[8];
+        const size_t size;
+    } mangleMagicVals[] = {
+        /* 1B - No endianness */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x01\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x02\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x03\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x04\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x05\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x06\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x07\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x08\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x09\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x0A\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x0B\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x0C\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x0D\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x0E\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x0F\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x10\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x20\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x40\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x7E\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x7F\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\x81\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\xC0\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\xFE\x00\x00\x00\x00\x00\x00\x00", 1},
+        {"\xFF\x00\x00\x00\x00\x00\x00\x00", 1},
+        /* 2B - NE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x01\x01\x00\x00\x00\x00\x00\x00", 2},
+        {"\x80\x80\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFF\xFF\x00\x00\x00\x00\x00\x00", 2},
+        /* 2B - BE */
+        {"\x00\x01\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x02\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x03\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x04\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x05\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x06\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x07\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x08\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x09\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x0A\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x0B\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x0C\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x0D\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x0E\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x0F\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x10\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x20\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x40\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x7E\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x7F\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x80\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x81\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\xC0\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\xFE\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\xFF\x00\x00\x00\x00\x00\x00", 2},
+        {"\x7E\xFF\x00\x00\x00\x00\x00\x00", 2},
+        {"\x7F\xFF\x00\x00\x00\x00\x00\x00", 2},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x80\x01\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFF\xFE\x00\x00\x00\x00\x00\x00", 2},
+        /* 2B - LE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x01\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x02\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x03\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x04\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x05\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x06\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x07\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x08\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x09\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x0A\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x0B\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x0C\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x0D\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x0E\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x0F\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x10\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x20\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x40\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x7E\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x7F\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\x81\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\xC0\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFE\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFF\x00\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFF\x7E\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFF\x7F\x00\x00\x00\x00\x00\x00", 2},
+        {"\x00\x80\x00\x00\x00\x00\x00\x00", 2},
+        {"\x01\x80\x00\x00\x00\x00\x00\x00", 2},
+        {"\xFE\xFF\x00\x00\x00\x00\x00\x00", 2},
+        /* 4B - NE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x01\x01\x01\x01\x00\x00\x00\x00", 4},
+        {"\x80\x80\x80\x80\x00\x00\x00\x00", 4},
+        {"\xFF\xFF\xFF\xFF\x00\x00\x00\x00", 4},
+        /* 4B - BE */
+        {"\x00\x00\x00\x01\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x02\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x03\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x04\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x05\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x06\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x07\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x08\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x09\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x0A\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x0B\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x0C\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x0D\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x0E\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x0F\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x10\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x20\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x40\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x7E\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x7F\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x80\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x81\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\xC0\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\xFE\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\xFF\x00\x00\x00\x00", 4},
+        {"\x7E\xFF\xFF\xFF\x00\x00\x00\x00", 4},
+        {"\x7F\xFF\xFF\xFF\x00\x00\x00\x00", 4},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x80\x00\x00\x01\x00\x00\x00\x00", 4},
+        {"\xFF\xFF\xFF\xFE\x00\x00\x00\x00", 4},
+        /* 4B - LE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x01\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x02\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x03\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x04\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x05\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x06\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x07\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x08\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x09\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x0A\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x0B\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x0C\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x0D\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x0E\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x0F\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x10\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x20\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x40\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x7E\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x7F\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\x81\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\xC0\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\xFE\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\xFF\x00\x00\x00\x00\x00\x00\x00", 4},
+        {"\xFF\xFF\xFF\x7E\x00\x00\x00\x00", 4},
+        {"\xFF\xFF\xFF\x7F\x00\x00\x00\x00", 4},
+        {"\x00\x00\x00\x80\x00\x00\x00\x00", 4},
+        {"\x01\x00\x00\x80\x00\x00\x00\x00", 4},
+        {"\xFE\xFF\xFF\xFF\x00\x00\x00\x00", 4},
+        /* 8B - NE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x01\x01\x01\x01\x01\x01\x01\x01", 8},
+        {"\x80\x80\x80\x80\x80\x80\x80\x80", 8},
+        {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8},
+        /* 8B - BE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x01", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x02", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x03", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x04", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x05", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x06", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x07", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x08", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x09", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x0A", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x0B", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x0C", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x0D", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x0E", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x0F", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x10", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x20", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x40", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x7E", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x7F", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x80", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x81", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\xC0", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\xFE", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\xFF", 8},
+        {"\x7E\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8},
+        {"\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x80\x00\x00\x00\x00\x00\x00\x01", 8},
+        {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE", 8},
+        /* 8B - LE */
+        {"\x00\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x01\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x02\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x03\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x04\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x05\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x06\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x07\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x08\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x09\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x0A\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x0B\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x0C\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x0D\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x0E\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x0F\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x10\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x20\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x40\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x7E\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x7F\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x80\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\x81\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\xC0\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\xFE\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\xFF\x00\x00\x00\x00\x00\x00\x00", 8},
+        {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7E", 8},
+        {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F", 8},
+        {"\x00\x00\x00\x00\x00\x00\x00\x80", 8},
+        {"\x01\x00\x00\x00\x00\x00\x00\x80", 8},
+        {"\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8},
+    };
+
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    uint64_t choice = util_rndGet(0, ARRAYSIZE(mangleMagicVals) - 1);
+    mangle_Overwrite(run, mangleMagicVals[choice].val, off, mangleMagicVals[choice].size);
+    /* FIXME */
+}
+
 static void mangle_MemSet(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     size_t sz = util_rndGet(1, run->dynamicFileSz - off);
@@ -394,10 +696,25 @@ static void mangle_MemSet(run_t* run) {
     memset(&run->dynamicFile[off], val, sz);
 }
 
+static void mangle_MemSetPrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    size_t sz = util_rndGet(1, run->dynamicFileSz - off);
+    int val = (int)util_rndPrintable();
+
+    memset(&run->dynamicFile[off], val, sz);
+}
+
 static void mangle_Random(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     size_t len = util_rndGet(1, run->dynamicFileSz - off);
     util_rndBuf(&run->dynamicFile[off], len);
+}
+
+static void mangle_RandomPrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    size_t len = util_rndGet(1, run->dynamicFileSz - off);
+    util_rndBuf(&run->dynamicFile[off], len);
+    util_turnToPrintable(&run->dynamicFile[off], len);
 }
 
 static void mangle_AddSub(run_t* run) {
@@ -470,9 +787,93 @@ static void mangle_AddSub(run_t* run) {
     }
 }
 
+static void mangle_AddSubPrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+
+    /* 1,2,4,8 */
+    uint64_t varLen = 1U << util_rndGet(0, 3);
+    if ((run->dynamicFileSz - off) < varLen) {
+        varLen = 1;
+    }
+
+    int delta = (int)util_rndGet(0, 8192);
+    delta -= 4096;
+
+    switch (varLen) {
+        case 1: {
+            run->dynamicFile[off] += delta;
+            break;
+        }
+        case 2: {
+            int16_t val;
+            memcpy(&val, &run->dynamicFile[off], sizeof(val));
+            if (util_rnd64() & 0x1) {
+                val += delta;
+            } else {
+                /* Foreign endianess */
+                val = __builtin_bswap16(val);
+                val += delta;
+                val = __builtin_bswap16(val);
+            }
+            mangle_Overwrite(run, (uint8_t*)&val, off, varLen);
+            break;
+        }
+        case 4: {
+            int32_t val;
+            memcpy(&val, &run->dynamicFile[off], sizeof(val));
+            if (util_rnd64() & 0x1) {
+                val += delta;
+            } else {
+                /* Foreign endianess */
+                val = __builtin_bswap32(val);
+                val += delta;
+                val = __builtin_bswap32(val);
+            }
+            mangle_Overwrite(run, (uint8_t*)&val, off, varLen);
+            break;
+        }
+        case 8: {
+            int64_t val;
+            memcpy(&val, &run->dynamicFile[off], sizeof(val));
+            if (util_rnd64() & 0x1) {
+                val += delta;
+            } else {
+                /* Foreign endianess */
+                val = __builtin_bswap64(val);
+                val += delta;
+                val = __builtin_bswap64(val);
+            }
+            mangle_Overwrite(run, (uint8_t*)&val, off, varLen);
+            break;
+        }
+        default: {
+            LOG_F("Unknown variable length size: %" PRIu64, varLen);
+            break;
+        }
+    }
+    util_turnToPrintable((uint8_t *)&run->dynamicFile[off], varLen);
+}
+
+static void addPrintable(uint8_t *byte) {
+    *byte = ((*byte) - 32 + 1) % 95 + 32;
+}
+
+static void decPrintable(uint8_t *byte) {
+    *byte = ((*byte) - 32 + 94) % 95 + 32;
+}
+
+static void negPrintable(uint8_t *byte) {
+    *byte = 95 - ((*byte) - 32) + 32;
+}
+
 static void mangle_IncByte(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     run->dynamicFile[off] += (uint8_t)1UL;
+}
+
+static void mangle_IncBytePrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    addPrintable(&run->dynamicFile[off]);
 }
 
 static void mangle_DecByte(run_t* run) {
@@ -480,9 +881,19 @@ static void mangle_DecByte(run_t* run) {
     run->dynamicFile[off] -= (uint8_t)1UL;
 }
 
+static void mangle_DecBytePrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    decPrintable(&run->dynamicFile[off]);
+}
+
 static void mangle_NegByte(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     run->dynamicFile[off] = ~(run->dynamicFile[off]);
+}
+
+static void mangle_NegBytePrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    negPrintable(&run->dynamicFile[off]);
 }
 
 static void mangle_CloneByte(run_t* run) {
@@ -528,12 +939,74 @@ static void mangle_InsertRnd(run_t* run) {
     util_rndBuf(&run->dynamicFile[off], len);
 }
 
+static void mangle_InsertRndPrintable(run_t* run) {
+    size_t off = util_rndGet(0, run->dynamicFileSz - 1);
+    size_t len = util_rndGet(1, run->dynamicFileSz - off);
+
+    mangle_Inflate(run, off, len);
+    mangle_Move(run, off, off + len, run->dynamicFileSz);
+    util_rndBuf(&run->dynamicFile[off], len);
+    util_turnToPrintable(&run->dynamicFile[off], len);
+}
+
 static void mangle_ASCIIVal(run_t* run) {
     char buf[32];
     snprintf(buf, sizeof(buf), "%" PRId64, (int64_t)util_rnd64());
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
 
     mangle_Overwrite(run, (uint8_t*)buf, off, strlen(buf));
+}
+
+static void (*mangleFuncs[])(run_t * run) = {
+    mangle_Resize,
+    mangle_Byte,
+    mangle_Bit,
+    mangle_Bytes,
+    mangle_Magic,
+    mangle_IncByte,
+    mangle_DecByte,
+    mangle_NegByte,
+    mangle_AddSub,
+    mangle_Dictionary,
+    mangle_DictionaryInsert,
+    mangle_MemMove,
+    mangle_MemSet,
+    mangle_Random,
+    mangle_CloneByte,
+    mangle_Expand,
+    mangle_Shrink,
+    mangle_InsertRnd,
+    mangle_ASCIIVal,
+};
+
+void mangle_init(bool only_printable) {
+    if (only_printable) {
+        static void (*const manglePrintableFuncs[])(run_t * run) = {
+            mangle_Resize,
+            mangle_PrintableByte,
+            mangle_BitPrintable,
+            mangle_PrintableBytes,
+            mangle_MagicPrintable,
+            mangle_IncBytePrintable,
+            mangle_DecBytePrintable,
+            mangle_NegBytePrintable,
+            mangle_AddSubPrintable,
+            mangle_DictionaryPrintable,
+            mangle_DictionaryInsertPrintable,
+            mangle_MemMove,
+            mangle_MemSetPrintable,
+            mangle_RandomPrintable,
+            mangle_CloneByte,
+            mangle_Expand,
+            mangle_Shrink,
+            mangle_InsertRndPrintable,
+            mangle_ASCIIVal,
+        };
+        if (ARRAYSIZE(mangleFuncs) != ARRAYSIZE(manglePrintableFuncs)) {
+            LOG_F("mangle function list sizes are different")
+        }
+        memcpy(mangleFuncs, manglePrintableFuncs, sizeof(mangleFuncs));
+    }
 }
 
 void mangle_mangleContent(run_t* run) {
@@ -545,28 +1018,6 @@ void mangle_mangleContent(run_t* run) {
     if (run->dynamicFileSz == 0UL) {
         input_setSize(run, 1UL);
     }
-
-    static void (*const mangleFuncs[])(run_t * run) = {
-        mangle_Resize,
-        mangle_Byte,
-        mangle_Bit,
-        mangle_Bytes,
-        mangle_Magic,
-        mangle_IncByte,
-        mangle_DecByte,
-        mangle_NegByte,
-        mangle_AddSub,
-        mangle_Dictionary,
-        mangle_DictionaryInsert,
-        mangle_MemMove,
-        mangle_MemSet,
-        mangle_Random,
-        mangle_CloneByte,
-        mangle_Expand,
-        mangle_Shrink,
-        mangle_InsertRnd,
-        mangle_ASCIIVal,
-    };
 
     /* Max number of stacked changes is 6 */
     uint64_t changesCnt = util_rndGet(1, run->global->mutate.mutationsPerRun);

--- a/mangle.c
+++ b/mangle.c
@@ -110,8 +110,8 @@ static void mangle_Bytes(run_t* run) {
 
 static void mangle_PrintableBytes(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
-    uint32_t val = (uint32_t)util_rnd64();
-    util_turnToPrintable((uint8_t *)&val, sizeof(val));
+    uint32_t val;
+    util_rndBufPrintable((uint8_t *)&val, sizeof(val));
 
     /* Overwrite with random 2,3,4-byte values */
     size_t toCopy = util_rndGet(2, 4);
@@ -713,8 +713,7 @@ static void mangle_Random(run_t* run) {
 static void mangle_RandomPrintable(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     size_t len = util_rndGet(1, run->dynamicFileSz - off);
-    util_rndBuf(&run->dynamicFile[off], len);
-    util_turnToPrintable(&run->dynamicFile[off], len);
+    util_rndBufPrintable(&run->dynamicFile[off], len);
 }
 
 static void mangle_AddSub(run_t* run) {

--- a/mangle.c
+++ b/mangle.c
@@ -974,7 +974,7 @@ static void mangle_InsertRndPrintable(run_t* run) {
     size_t off = util_rndGet(0, run->dynamicFileSz - 1);
     size_t len = util_rndGet(1, run->dynamicFileSz - off);
 
-    mangle_Inflate(run, off, len);
+    mangle_InflatePrintable(run, off, len);
     mangle_Move(run, off, off + len, run->dynamicFileSz);
     util_rndBuf(&run->dynamicFile[off], len);
     util_turnToPrintable(&run->dynamicFile[off], len);

--- a/mangle.c
+++ b/mangle.c
@@ -868,8 +868,7 @@ static void mangle_InsertRndPrintable(run_t* run) {
 
     mangle_Inflate(run, off, len);
     mangle_Move(run, off, off + len, run->dynamicFileSz);
-    util_rndBuf(&run->dynamicFile[off], len);
-    util_turnToPrintable(&run->dynamicFile[off], len);
+    util_rndBufPrintable(&run->dynamicFile[off], len);
 }
 
 static void mangle_ASCIIVal(run_t* run) {

--- a/mangle.h
+++ b/mangle.h
@@ -26,6 +26,7 @@
 
 #include "honggfuzz.h"
 
+extern void mangle_init(bool only_printable);
 extern void mangle_mangleContent(run_t* run);
 
 #endif


### PR DESCRIPTION
The "only-printable" mode will only generate printable inputs for the fuzzed program. This might be useful for many applications such as expr(1). The changes to achieve this are:

1. Add an option and configuration flag for the "only-printable" mode;
2. Change the initial single-byte input from '\0' to ' ' (a space character) under this mode;
3. Implement the printable version of mangle functions;
4. Add initialization function to reset the mangle function list.

The printable version of "mangle_Magic" is currently implemented as directly transferring the original data to printable outputs. Because I don't know the semantics of this function. If anyone has any suggestion for this, I'd like to improve it.