### PR TITLE
Use the canonical flag for POSIX threads dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifeq ($(OS)$(findstring Microsoft,$(KERNEL)),Linux) # matches Linux but excludes
                    -funroll-loops \
                    -D_FILE_OFFSET_BITS=64
     ARCH_LDFLAGS := -L/usr/local/include \
-                    -lpthread -lunwind-ptrace -lunwind-generic -lbfd -lopcodes -lrt -ldl
+                    -pthread -lunwind-ptrace -lunwind-generic -lbfd -lopcodes -lrt -ldl
     ARCH_SRCS := $(sort $(wildcard linux/*.c))
     LIBS_CFLAGS += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 

--- a/hfuzz_cc/hfuzz-cc.c
+++ b/hfuzz_cc/hfuzz-cc.c
@@ -391,7 +391,7 @@ static int ldMode(int argc, char** argv) {
 #endif /* _HF_ARCH_DARWIN */
 
     /* Needed by the libhfcommon */
-    args[j++] = "-lpthread";
+    args[j++] = "-pthread";
 
     return execCC(j, args);
 }


### PR DESCRIPTION
Replace -lpthread with -pthread.

A compiler might append additional flags with the -pthread flag,
such as -D_REENTRANT.