### PR TITLE
Print proper Thread Id in logs on NetBSD

### DIFF
--- a/libhfcommon/log.c
+++ b/libhfcommon/log.c
@@ -41,9 +41,12 @@
 #if defined(_HF_ARCH_LINUX)
 #include <sys/syscall.h>
 #define __hf_pid() (pid_t) syscall(__NR_gettid)
-#else /* defined(_HF_ARCH_LINUX) */
+#elif defined(_HF_ARCH_NETBSD)
+#include <lwp.h>
+#define __hf_pid() _lwp_self()
+#else
 #define __hf_pid() getpid()
-#endif /* defined(_HF_ARCH_LINUX) */
+#endif
 
 static int log_fd = STDERR_FILENO;
 static bool log_fd_isatty = false;


### PR DESCRIPTION
All threads on NetBSD have the same process id and distinct thread id.

Add a conditional compilation switch for NetBSD, to implement __hf_pid()
with NetBSD specific call to return the Thread ID, in NetBSD terminolog
LWP ID (ligth-weight process identification).