### PR TITLE
Fixes for fuzzing on NetBSD with concurrent fuzzer-threads

### DIFF
--- a/netbsd/arch.c
+++ b/netbsd/arch.c
@@ -202,7 +202,7 @@ static bool arch_checkWait(run_t* run) {
     /* All queued wait events must be tested when SIGCHLD was delivered */
     for (;;) {
         int status;
-        pid_t pid = TEMP_FAILURE_RETRY(waitpid(WAIT_ANY, &status, WALLSIG | WNOHANG));
+        pid_t pid = TEMP_FAILURE_RETRY(waitpid(ptracePid, &status, WALLSIG | WNOHANG));
         if (pid == 0) {
             return false;
         }


### PR DESCRIPTION
Do not support fuzzing forkees and vforkees. Doing so is non-trivial
in the current design of the fuzzer, as there is need to call wait(2)
function dedicated for every forkee and vforkee in a thread. In the
context of fuzzing in multiple instances of multiple processes this
means that there is need a redesign of the threading/process model
and wait(2)ing every tracee with a dedicated thread or iteration step
in a loop (perhaps try kqueue(2)/kevent(2)?).

A wait(2)-like function called for WAIT_ANY caused gathering reports
from other fuzzer-threads and in the result abnormal hangs.

While there, do not discard SIGTRAP that is emitted by user, and pass
this signal to the tracee.