### PR TITLE
Handle NetBSD in generic code switches

### DIFF
--- a/display.c
+++ b/display.c
@@ -181,9 +181,17 @@ static void display_displayLocked(honggfuzz_t* hfuzz) {
             break;
     }
 
+#if defined(_HF_ARCH_LINUX)
     if (hfuzz->linux.pid > 0) {
         display_put("      Target : [" ESC_BOLD "%d" ESC_RESET "] '" ESC_BOLD "%s" ESC_RESET "'\n",
             hfuzz->linux.pid, hfuzz->linux.pidCmd);
+#elif defined(_HF_ARCH_NETBSD)
+    if (hfuzz->netbsd.pid > 0) {
+        display_put("      Target : [" ESC_BOLD "%d" ESC_RESET "] '" ESC_BOLD "%s" ESC_RESET "'\n",
+            hfuzz->netbsd.pid, hfuzz->netbsd.pidCmd);
+#else
+    if (false) {
+#endif
     } else {
         display_put("      Target : " ESC_BOLD "%s" ESC_RESET "\n", hfuzz->display.cmdline_txt);
     }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -260,12 +260,21 @@ int main(int argc, char** argv) {
     if (hfuzz.feedback.blacklist) {
         free(hfuzz.feedback.blacklist);
     }
+#if defined(_HF_ARCH_LINUX)
     if (hfuzz.linux.symsBl) {
         free(hfuzz.linux.symsBl);
     }
     if (hfuzz.linux.symsWl) {
         free(hfuzz.linux.symsWl);
     }
+#elif defined(_HF_ARCH_NETBSD)
+    if (hfuzz.netbsd.symsBl) {
+        free(hfuzz.netbsd.symsBl);
+    }
+    if (hfuzz.netbsd.symsWl) {
+        free(hfuzz.netbsd.symsWl);
+    }
+#endif
     if (hfuzz.socketFuzzer.enabled) {
         cleanupSocketFuzzer();
     }

--- a/report.c
+++ b/report.c
@@ -97,7 +97,7 @@ void report_Report(run_t* run) {
         " externalCmd     : %s\n"
         " fuzzStdin       : %s\n"
         " timeout         : %ld (sec)\n"
-#if defined(_HF_ARCH_LINUX)
+#if defined(_HF_ARCH_LINUX) || defined(_HF_ARCH_NETBSD)
         " ignoreAddr      : %p\n"
 #endif
         " ASLimit         : %" PRIu64
@@ -106,7 +106,7 @@ void report_Report(run_t* run) {
         " (MiB)\n"
         " DATALimit       : %" PRIu64
         " (MiB)\n"
-#if defined(_HF_ARCH_LINUX)
+#if defined(_HF_ARCH_LINUX) || defined(_HF_ARCH_NETBSD)
         " targetPid       : %d\n"
         " targetCmd       : %s\n"
 #endif
@@ -116,10 +116,14 @@ void report_Report(run_t* run) {
         run->global->exe.fuzzStdin ? "TRUE" : "FALSE", run->global->timing.tmOut,
 #if defined(_HF_ARCH_LINUX)
         run->global->linux.ignoreAddr,
+#elif defined(_HF_ARCH_NETBSD)
+        run->global->netbsd.ignoreAddr,
 #endif
         run->global->exe.asLimit, run->global->exe.rssLimit, run->global->exe.dataLimit,
 #if defined(_HF_ARCH_LINUX)
         run->global->linux.pid, run->global->linux.pidCmd,
+#elif defined(_HF_ARCH_NETBSD)
+        run->global->netbsd.pid, run->global->netbsd.pidCmd,
 #endif
         run->global->mutate.dictionaryFile == NULL ? "NULL" : run->global->mutate.dictionaryFile);
 

--- a/sancov.c
+++ b/sancov.c
@@ -309,7 +309,13 @@ static bool sancov_sanCovParseRaw(run_t* run) {
     off_t dataFileSz = 0, pos = 0;
     bool is32bit = true;
     char covFile[PATH_MAX] = {0};
+#if defined(_HF_ARCH_LINUX)
     pid_t targetPid = (run->global->linux.pid > 0) ? run->global->linux.pid : run->pid;
+#elif defined(_HF_ARCH_NETBSD)
+    pid_t targetPid = (run->global->netbsd.pid > 0) ? run->global->netbsd.pid : run->pid;
+#else
+    pid_t targetPid = run->pid;
+#endif
 
     /* Fuzzer local runtime data structs - need free() before exit */
     uint64_t* startMapsIndex = NULL;
@@ -424,7 +430,7 @@ static bool sancov_sanCovParseRaw(run_t* run) {
     }
 
     /* Delete .sancov.map file */
-    if (run->global->linux.pid == 0 && run->global->exe.persistent == false) {
+    if (run->global->linux.pid == 0 && run->global->netbsd.pid == 0 && run->global->exe.persistent == false) {
         unlink(covFile);
     }
 
@@ -561,7 +567,7 @@ static bool sancov_sanCovParseRaw(run_t* run) {
     run->sanCovCnts.dsoCnt = mapsNum;
     run->sanCovCnts.iDsoCnt = mapsNum - noCovMapsNum; /* Instrumented DSOs */
 
-    if (run->global->linux.pid == 0 && run->global->exe.persistent == false) {
+    if (run->global->linux.pid == 0 && run->global->netbsd.pid == 0 && run->global->exe.persistent == false) {
         unlink(covFile);
     }
     return true;
@@ -574,7 +580,13 @@ static bool sancov_sanCovParse(run_t* run) {
     bool is32bit = true;
     char covFile[PATH_MAX] = {0};
     DIR* pSanCovDir = NULL;
+#if defined(_HF_ARCH_LINUX)
     pid_t targetPid = (run->global->linux.pid > 0) ? run->global->linux.pid : run->pid;
+#elif defined(_HF_ARCH_NETBSD)
+    pid_t targetPid = (run->global->netbsd.pid > 0) ? run->global->netbsd.pid : run->pid;
+#else
+    pid_t targetPid = run->pid;
+#endif
 
     snprintf(covFile, sizeof(covFile), "%s/%s/%s.%d.sancov", run->global->io.workDir,
         _HF_SANCOV_DIR, files_basename(run->global->exe.cmdline[0]), targetPid);
@@ -662,7 +674,7 @@ static bool sancov_sanCovParse(run_t* run) {
     /* Successful parsing - update fuzzer worker counters */
     run->sanCovCnts.hitBBCnt = nBBs;
 
-    if (run->global->linux.pid == 0 && run->global->exe.persistent == false) {
+    if (run->global->linux.pid == 0 && run->global->netbsd.pid == 0 && run->global->exe.persistent == false) {
         unlink(covFile);
     }
     return true;

--- a/sanitizers.c
+++ b/sanitizers.c
@@ -141,9 +141,15 @@ static void sanitizers_AddFlag(honggfuzz_t* hfuzz, const char* env, char* buf, s
 }
 
 bool sanitizers_Init(honggfuzz_t* hfuzz) {
+#if defined(_HF_ARCH_LINUX)
     if (hfuzz->linux.pid > 0) {
         return true;
     }
+#elif defined(_HF_ARCH_NETBSD)
+    if (hfuzz->netbsd.pid > 0) {
+        return true;
+    }
+#endif
 
     static char asanOpts[4096];
     sanitizers_AddFlag(hfuzz, "ASAN_OPTIONS", asanOpts, sizeof(asanOpts));


### PR DESCRIPTION
Enhance the NetBSD support in generic code using the linux struct,
and where applicable use the netbsd struct.