### PR TITLE
Fix socketfuzzer test code for interactive mode

### DIFF
--- a/socketfuzzer/Makefile
+++ b/socketfuzzer/Makefile
@@ -2,4 +2,4 @@ all: vulnserver_cov
 
 vulnserver_cov:
 	unset HFUZZ_CC_ASAN
-	../hfuzz_cc/hfuzz-gcc vulnserver_cov.c -o vulnserver_cov
+	../hfuzz_cc/hfuzz-cc vulnserver_cov.c -o vulnserver_cov

--- a/socketfuzzer/honggfuzz_socketclient.py
+++ b/socketfuzzer/honggfuzz_socketclient.py
@@ -268,7 +268,7 @@ def interactive(pid):
     hfSocket = HonggfuzzSocket(pid)
     targetSocket = TargetSocket()
 
-    hfSocket.connect("/tmp/honggfuzz_socket")
+    hfSocket.connect()
 
     while(True):
         try:


### PR DESCRIPTION
The interactive mode for the socketfuzzer test code was passing illegal argument to connect so I've fixed that and gcc 5.4 does not have the `fsanitize-coverage` option so changed it to clang instead. 