### PR TITLE
linux/perf.c: Fix `cpuIptBtsFd` assignment on failed perf set-up

### DIFF
--- a/linux/perf.c
+++ b/linux/perf.c
@@ -251,7 +251,7 @@ out:
     close(run->linux.cpuBranchFd);
     run->linux.cpuBranchFd = -1;
     close(run->linux.cpuIptBtsFd);
-    run->linux.cpuIptBtsFd = 1;
+    run->linux.cpuIptBtsFd = -1;
 
     return false;
 }


### PR DESCRIPTION
`run->linux.cpuIptBtsFd` should be set to -1 instead of 1 on failed perf
set-up. This patch fixes that mistake.

Signed-off-by: Solomon Tan <solomonbstoner@protonmail.ch>