### PR TITLE
linux/perf.c: Assign perfMmapAux pointer to NULL upon failed mmap

### DIFF
--- a/linux/perf.c
+++ b/linux/perf.c
@@ -199,6 +199,7 @@ static bool arch_perfCreate(run_t* run, pid_t pid, dynFileMethod_t method, int* 
              NULL, pem->aux_size, PROT_READ, MAP_SHARED, *perfFd, pem->aux_offset)) == MAP_FAILED) {
         munmap(run->linux.perfMmapBuf, _HF_PERF_MAP_SZ + getpagesize());
         run->linux.perfMmapBuf = NULL;
+        run->linux.perfMmapAux = NULL;
         PLOG_W(
             "mmap(mmapAuxBuf) failed, try increasing the kernel.perf_event_mlock_kb sysctl (up to "
             "even 300000000)");


### PR DESCRIPTION
When mmap fails to map memory for `run->linux.perfMmapAux`, the pointer
should be set to NULL. This is also done for `run->linux.perfMmapBuf`.

Signed-off-by: Solomon Tan <solomonbstoner@protonmail.ch>