### PR TITLE
Add support for external custom feedback data mutator command

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -274,6 +274,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .fuzzStdin = false,
                 .externalCommand = NULL,
                 .postExternalCommand = NULL,
+                .feedbackMutateCommand = NULL,
                 .persistent = false,
                 .netDriver = false,
                 .asLimit = 0U,
@@ -420,6 +421,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "stackhash_bl", required_argument, NULL, 'B' }, "Stackhashes blacklist file (one entry per line)" },
         { { "mutate_cmd", required_argument, NULL, 'c' }, "External command producing fuzz files (instead of internal mutators)" },
         { { "pprocess_cmd", required_argument, NULL, 0x104 }, "External command postprocessing files produced by internal mutators" },
+        { { "ffmutate_cmd", required_argument, NULL, 0x110 }, "External command mutating files which have effective coverage feedback" },
         { { "run_time", required_argument, NULL, 0x109 }, "Number of seconds this fuzzing session will last (default: 0 [no limit])" },
         { { "iterations", required_argument, NULL, 'N' }, "Number of fuzzing iterations (default: 0 [no limit])" },
         { { "rlimit_as", required_argument, NULL, 0x100 }, "Per process RLIMIT_AS in MiB (default: 0 [no limit])" },
@@ -594,6 +596,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
             case 0x104:
                 hfuzz->exe.postExternalCommand = optarg;
                 break;
+            case 0x110:
+                hfuzz->exe.feedbackMutateCommand = optarg;
+                break;    
             case 0x105:
                 if ((strcasecmp(optarg, "0") == 0) || (strcasecmp(optarg, "false") == 0)) {
                     hfuzz->cfg.monitorSIGABRT = false;

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -207,6 +207,7 @@ typedef struct {
         bool fuzzStdin;
         const char* externalCommand;
         const char* postExternalCommand;
+        const char* feedbackMutateCommand;
         bool netDriver;
         bool persistent;
         uint64_t asLimit;

--- a/input.h
+++ b/input.h
@@ -31,9 +31,10 @@ extern bool input_getNext(run_t* run, char* fname, bool rewind);
 extern bool input_init(honggfuzz_t* hfuzz);
 extern bool input_parseDictionary(honggfuzz_t* hfuzz);
 extern bool input_parseBlacklist(honggfuzz_t* hfuzz);
-extern bool input_prepareDynamicInput(run_t* run);
-extern bool input_prepareStaticFile(run_t* run, bool rewind);
+extern bool input_prepareDynamicInput(run_t* run, bool need_mangele);
+extern bool input_prepareStaticFile(run_t* run, bool rewind, bool need_mangele);
 extern bool input_prepareExternalFile(run_t* run);
 extern bool input_postProcessFile(run_t* run);
+extern bool input_feedbackMutateFile(run_t* run);
 
 #endif /* ifndef _HF_INPUT_H_ */


### PR DESCRIPTION
I find there is not exist a custom mutator option for feedback data in honggfuzz, so I add an option for using external custom data mutator, which can be used for mutating files by custom logic instead of mutating by internal mutators. And I think this maybe more useful for add custom [structure-aware](https://github.com/google/fuzzer-test-suite/blob/master/tutorial/structure-aware-fuzzing.md) mutator