### PR TITLE
fix for #253

### DIFF
--- a/socketfuzzer/Makefile
+++ b/socketfuzzer/Makefile
@@ -1,5 +1,5 @@
 all: vulnserver_cov
 
-vulnserver_cov:
+vulnserver_cov: vulnserver_cov.c
 	unset HFUZZ_CC_ASAN
 	../hfuzz_cc/hfuzz-cc vulnserver_cov.c -o vulnserver_cov

--- a/socketfuzzer/unittest.sh
+++ b/socketfuzzer/unittest.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-rm -rf HONGGFUZZ.REPORT.TXT SIGABR* HF.san*
+rm HONGGFUZZ.REPORT.TXT SIGABR* HF.san* SIGSEGV.*.fuzz
 
 ../honggfuzz --keep_output --debug --sanitizers --stdin_input --threads 1 --verbose --logfile log.txt --socket_fuzzer -- ./vulnserver_cov &
-
 python ./honggfuzz_socketclient.py auto $!


### PR DESCRIPTION
Some of the code rework in honggfuzz made the socketfuzzer work unrealiably. This PR fixes it by identifying if the fuzzed process has crashed, or is determined unresponsive by the external fuzzer, and restarts it correctly.

The corresponding unit test have been updated and its output made nicer. 

