### PR TITLE
add new statistic collection

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -288,8 +288,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .timeStart = time(NULL),
                 .runEndTime = 0,
                 .tmOut = 10,
-                .tmoutVTALRM = false,
                 .lastCovUpdate = time(NULL),
+                .timeOfLongestUnitInMilliseconds = 0,
+                .tmoutVTALRM = false,
             },
         .mutate =
             {
@@ -312,6 +313,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .report_mutex = PTHREAD_MUTEX_INITIALIZER,
                 .reportFile = NULL,
                 .dynFileIterExpire = 0,
+                .reportSlowUnits = 10000LL,
 #if defined(__ANDROID__)
                 .monitorSIGABRT = false,
 #else
@@ -441,6 +443,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "socket_fuzzer", no_argument, NULL, 0x10B }, "Instrument external fuzzer via socket" },
         { { "netdriver", no_argument, NULL, 0x10C }, "Use netdriver (libhfnetdriver/). In most cases it will be autodetected through a binary signature" },
         { { "only_printable", no_argument, NULL, 'o' }, "Only generate printable inputs" },
+        { { "report_slow_units", required_argument, NULL, 0x10D}, "Report slowest units if they run for more than this number of milliseconds (default: 10'000)"},
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blacklist filter file (one entry per line)" },
@@ -563,6 +566,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 break;
             case 'R':
                 hfuzz->cfg.reportFile = optarg;
+                break;
+            case 0x10D:
+                hfuzz->cfg.reportSlowUnits = strtoll(optarg, NULL, 10);
                 break;
             case 'n':
                 if (optarg[0] == 'a') {

--- a/fuzz.c
+++ b/fuzz.c
@@ -120,6 +120,7 @@ static void fuzz_addFileToFileQ(honggfuzz_t* hfuzz, const uint8_t* data, size_t 
     MX_SCOPED_RWLOCK_WRITE(&hfuzz->io.dynfileq_mutex);
     TAILQ_INSERT_TAIL(&hfuzz->io.dynfileq, dynfile, pointers);
     hfuzz->io.dynfileqCnt++;
+    hfuzz->io.new_units_added++;
 
     if (hfuzz->socketFuzzer.enabled) {
         /* Don't add coverage data to files in socketFuzzer mode */
@@ -168,6 +169,7 @@ static void fuzz_setDynamicMainState(run_t* run) {
 
     LOG_I("Entering phase 3/3: Dynamic Main (Feedback Driven Mode)");
     snprintf(run->origFileName, sizeof(run->origFileName), "[DYNAMIC]");
+    run->global->io.new_units_added = 0;
     ATOMIC_SET(run->global->feedback.state, _HF_STATE_DYNAMIC_MAIN);
 
     /*

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -189,8 +189,12 @@ static void printSummary(honggfuzz_t* hfuzz) {
     if (elapsed_sec) {
         exec_per_sec = hfuzz->cnts.mutationsCnt / elapsed_sec;
     }
-    LOG_I("Summary iterations:%zu time:%" PRIu64 " speed:%" PRIu64, hfuzz->cnts.mutationsCnt,
-        elapsed_sec, exec_per_sec);
+    LOG_I("Summary iterations:%zu time:%" PRIu64 " speed:%" PRIu64 " "
+          "crashes_count:%zu timeout_count:%zu new_units_added:%zu "
+          "slowest_unit_ms:%" PRId64 ,
+          hfuzz->cnts.mutationsCnt, elapsed_sec, exec_per_sec,
+          hfuzz->cnts.crashesCnt, hfuzz->cnts.timeoutedCnt, hfuzz->io.new_units_added,
+          hfuzz->timing.timeOfLongestUnitInMilliseconds);
 }
 
 static void pingThreads(honggfuzz_t* hfuzz) {

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -191,6 +191,7 @@ typedef struct {
         size_t fileCnt;
         const char* fileExtn;
         bool fileCntDone;
+        size_t new_units_added;
         const char* workDir;
         const char* crashDir;
         const char* covDirAll;
@@ -223,6 +224,7 @@ typedef struct {
         time_t runEndTime;
         time_t tmOut;
         time_t lastCovUpdate;
+        int64_t timeOfLongestUnitInMilliseconds;
         bool tmoutVTALRM;
     } timing;
     struct {
@@ -245,6 +247,7 @@ typedef struct {
         pthread_mutex_t report_mutex;
         bool monitorSIGABRT;
         size_t dynFileIterExpire;
+        int64_t reportSlowUnits;
         bool only_printable;
     } cfg;
     struct {

--- a/subproc.c
+++ b/subproc.c
@@ -173,6 +173,12 @@ bool subproc_persistentModeStateMachine(run_t* run) {
                 if (!subproc_persistentGetReady(run)) {
                     return false;
                 }
+                int64_t curMillis = util_timeNowMillis();
+                int64_t diffMillis = curMillis - run->timeStartedMillis;
+                if (diffMillis > (ATOMIC_GET(run->global->timing.timeOfLongestUnitInMilliseconds) * 1.1) && diffMillis > run->global->cfg.reportSlowUnits) {
+                    LOG_D("Found new slowest unit, runs in %" PRId64 " ms", diffMillis);
+                    ATOMIC_SET(run->global->timing.timeOfLongestUnitInMilliseconds, diffMillis);
+                }
                 run->runState = _HF_RS_SEND_DATA;
                 /* The current persistent round is done */
                 return true;


### PR DESCRIPTION
- add crashes count and timeouted count to the final summary.
- add `new_units_added` "[libfuzzer like](https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/fuzzer/FuzzerLoop.cpp#L364)" statitic - counts the number of new samples added in the corpus during this run because of new coverage found.
- add slowest unit - after each round, update the `timeOfLongestUnitInMilliseconds` if the round was more than 10% slower than the slowest one so far. Timeouts are not considered.