### PR TITLE
add branch_coverage_percent and guard_nb statistics

### DIFF
--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -189,12 +189,14 @@ static void printSummary(honggfuzz_t* hfuzz) {
     if (elapsed_sec) {
         exec_per_sec = hfuzz->cnts.mutationsCnt / elapsed_sec;
     }
+    uint64_t branch_percent_cov = (100*hfuzz->linux.hwCnts.softCntEdge) / hfuzz->feedback.feedbackMap->guardNb;
     LOG_I("Summary iterations:%zu time:%" PRIu64 " speed:%" PRIu64 " "
           "crashes_count:%zu timeout_count:%zu new_units_added:%zu "
-          "slowest_unit_ms:%" PRId64,
+          "slowest_unit_ms:%" PRId64 " guard_nb:%" PRIu64 " branch_coverage_percent:%" PRIu64,
         hfuzz->cnts.mutationsCnt, elapsed_sec, exec_per_sec, hfuzz->cnts.crashesCnt,
         hfuzz->cnts.timeoutedCnt, hfuzz->io.newUnitsAdded,
-        hfuzz->timing.timeOfLongestUnitInMilliseconds);
+        hfuzz->timing.timeOfLongestUnitInMilliseconds, hfuzz->feedback.feedbackMap->guardNb,
+        branch_percent_cov);
 }
 
 static void pingThreads(honggfuzz_t* hfuzz) {

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -174,6 +174,7 @@ typedef struct {
     uint64_t pidFeedbackPc[_HF_THREAD_MAX];
     uint64_t pidFeedbackEdge[_HF_THREAD_MAX];
     uint64_t pidFeedbackCmp[_HF_THREAD_MAX];
+    uint64_t guardNb;
 } feedback_t;
 
 typedef struct {

--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -310,6 +310,11 @@ ATTRIBUTE_X86_REQUIRE_SSE42 void __sanitizer_cov_trace_pc_guard_init(
         /* If the corresponding PC was already hit, map this specific guard as uninteresting (0) */
         *x = ATOMIC_GET(feedback->pcGuardMap[n]) ? 0U : n;
     }
+
+    /*stores the number of guards for statistics purpose*/
+    if (ATOMIC_GET(feedback->guardNb) < n-1){
+        ATOMIC_SET(feedback->guardNb, n-1);
+    }
 }
 
 ATTRIBUTE_X86_REQUIRE_SSE42 void __sanitizer_cov_trace_pc_guard(uint32_t* guard) {


### PR DESCRIPTION
- Stores the number of guards at the end of the `__sanitizer_cov_trace_pc_guard_init`. The number of guards is n-1 because of the post increment in the for loop.

- Prints the percentage of guards hit. 