### PR TITLE
qemu_mode: initial support

### DIFF
--- a/qemu_mode/Makefile
+++ b/qemu_mode/Makefile
@@ -1,0 +1,22 @@
+
+.PHONY: clean qemu_bin
+
+TARGETS ?= x86_64-linux-user
+
+qemu_bin: honggfuzz-qemu/config.status
+	@echo "\nRun \"cd honggfuzz-qemu/ && make\"."
+	@echo "Targets: \"honggfuzz-qemu/*-linux-user/qemu-*\".\n"
+
+honggfuzz-qemu/config.status: honggfuzz-qemu/
+	@echo "=== Configuring QEMU for \"$(TARGETS)\" ==="
+	@cd honggfuzz-qemu/ && \
+		./configure --honggfuzz-path="$(PWD)/../" --disable-system --target-list="$(TARGETS)"
+
+honggfuzz-qemu/:
+	@echo "=== Cloning custom QEMU version ==="
+	@git clone --depth 1 https://github.com/thebabush/honggfuzz-qemu.git -b honggfuzz
+
+clean:
+	@echo "=== Cleaning ==="
+	rm -rf honggfuzz-qemu/
+


### PR DESCRIPTION
PoC for qemu_mode.

I don't like AFL's way of building from a specific tarball + applying patches, but QEMU uses submodules so downloading from github as a zip doesn't work.

The idea for now is that I keep a QEMU repo where the `honggfuzz` branch is the current implementation.
AFL's way looks better for more stable stuff.

Let me know what you think.
If you want a more trusted pipeline, I'll do it like AFL does.

So far the coverage implemented is:

- basic block
- cmp

I'm instrumenting instructions in the disassembler. AFAIK that's the most stable and clean option. For x86 I just instrument `cmp`s and on ARM a bunch of instructions. Unfortunately, t's difficult to understand what needs to be instrumented without some empirical data.

It would be nice to have some CI going on since QEMU is huge and complex but for now it seems to work ok.
