### PR TITLE
Convert maxrss to mb

### DIFF
--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -200,6 +200,11 @@ static void printSummary(honggfuzz_t* hfuzz) {
         PLOG_W("getrusage  failed");
         usage.ru_maxrss = 0;  // 0 means something went wrong with rusage
     }
+#ifdef _HF_ARCH_DARWIN
+    usage.ru_maxrss >>= 20;
+#else
+    usage.ru_maxrss >>= 10;
+#endif
     LOG_I("Summary iterations:%zu time:%" PRIu64 " speed:%" PRIu64 " "
           "crashes_count:%zu timeout_count:%zu new_units_added:%zu "
           "slowest_unit_ms:%" PRId64 " guard_nb:%" PRIu64 " branch_coverage_percent:%" PRIu64 " "


### PR DESCRIPTION
As found in an AFL PR ( https://github.com/google/AFL/pull/15#discussion_r320526405 ), I made the same mistake in honggfuzz and forgot to convert the `maxrss` value return by `getrusage` to mb.