### PR TITLE
Added option to export the feedback struct to disk

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -261,6 +261,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .dynfileqCnt = 0U,
                 .dynfileq_mutex = PTHREAD_RWLOCK_INITIALIZER,
                 .dynfileqCurrent = NULL,
+                .exportFeedback = false,
             },
         .exe =
             {
@@ -442,6 +443,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "socket_fuzzer", no_argument, NULL, 0x10B }, "Instrument external fuzzer via socket" },
         { { "netdriver", no_argument, NULL, 0x10C }, "Use netdriver (libhfnetdriver/). In most cases it will be autodetected through a binary signature" },
         { { "only_printable", no_argument, NULL, 0x10D }, "Only generate printable inputs" },
+        { { "export_feedback", no_argument, NULL, 0x10E }, "Export the coverage feedback structure as ./hfuzz-feedback" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blacklist filter file (one entry per line)" },
@@ -550,6 +552,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 break;
             case 0x10D:
                 hfuzz->cfg.only_printable = true;
+                break;
+            case 0x10E:
+                hfuzz->io.exportFeedback = true;
                 break;
             case 'z':
                 hfuzz->feedback.dynFileMethod |= _HF_DYNFILE_SOFT;

--- a/fuzz.c
+++ b/fuzz.c
@@ -492,7 +492,7 @@ static void* fuzz_threadNew(void* arg) {
     /* Do not try to handle input files with socketfuzzer */
     if (!hfuzz->socketFuzzer.enabled) {
         if (!(run.dynamicFile = files_mapSharedMem(hfuzz->mutate.maxFileSz, &run.dynamicFileFd,
-                  "hfuzz-input", /* nocore= */ true))) {
+                  "hfuzz-input", /* nocore= */ true, /* export= */ false))) {
             LOG_F("Couldn't create an input file of size: %zu", hfuzz->mutate.maxFileSz);
         }
     }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -360,7 +360,7 @@ int main(int argc, char** argv) {
     }
 
     if (!(hfuzz.feedback.feedbackMap = files_mapSharedMem(
-              sizeof(feedback_t), &hfuzz.feedback.bbFd, "hfuzz-feedback", /* nocore= */ true))) {
+              sizeof(feedback_t), &hfuzz.feedback.bbFd, "hfuzz-feedback", /* nocore= */ true, /* export= */ hfuzz.io.exportFeedback))) {
         LOG_F("files_mapSharedMem(sz=%zu, dir='%s') failed", sizeof(feedback_t), hfuzz.io.workDir);
     }
 

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -202,6 +202,7 @@ typedef struct {
         pthread_rwlock_t dynfileq_mutex;
         struct dynfile_t* dynfileqCurrent;
         TAILQ_HEAD(dyns_t, dynfile_t) dynfileq;
+        bool exportFeedback;
     } io;
     struct {
         int argc;

--- a/libhfcommon/files.h
+++ b/libhfcommon/files.h
@@ -60,7 +60,7 @@ extern uint8_t* files_mapFile(const char* fileName, off_t* fileSz, int* fd, bool
 
 extern int files_getTmpMapFlags(int flag, bool nocore);
 
-extern void* files_mapSharedMem(size_t sz, int* fd, const char* name, bool nocore);
+extern void* files_mapSharedMem(size_t sz, int* fd, const char* name, bool nocore, bool export);
 
 extern size_t files_parseSymbolFilter(const char* inFIle, char*** filterList);
 


### PR DESCRIPTION
Hi, I added a new commandline option to export the feedback_t struct to disk. I'm using that so I can afterwards fairly conveniently visualize the fuzz coverage of a binary. I'm not sure if this is a useful feature in general, and it might also be somewhat problematic as it's now essentially exporting an implementation detail...