### PR TITLE
netdriver: Make temporary directory overridable

### DIFF
--- a/libhfnetdriver/netdriver.h
+++ b/libhfnetdriver/netdriver.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +21,10 @@ int HonggfuzzNetDriverArgsForServer(int argc, char** argv, int* server_argc, cha
  * TCP port that the fuzzed data inputs will be sent to
  */
 uint16_t HonggfuzzNetDriverPort(int argc, char** argv);
+/*
+ * Mount point for temporary filesystem
+ */
+int HonggfuzzNetDriverTempdir(char *str, size_t size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Commit 627189739 changed the name of the path at which a tmpfs is
mounted for the duration of a main program from "/tmp/FUZZ" to
"/tmp/HFND_TMP_DIR". This change adds a weak-linked function allowing
fuzzers to override the temporary directory, e.g.:

```
int HonggfuzzNetDriverTempdir(char *str, size_t size)
{
   return snprintf(str, size, "/tmp/foo.%d", getpid());
}
```

This is particularily useful when multiple users share a system and
shouldn't each other. A future change could make the code use
mkdtemp(3).

The default path remains "/tmp/HFND_TMP_DIR" and the "/tmp/FUZZ"
directory isn't affected by this change.