### PR TITLE
sanitizers: Disable ODR violation detection

### DIFF
--- a/sanitizers.c
+++ b/sanitizers.c
@@ -68,6 +68,7 @@
 #define kASAN_COMMON_OPTS        \
     "allow_user_segv_handler=1:" \
     "handle_segv=0:"             \
+    "detect_odr_violation=0:"    \
     "allocator_may_return_null=1:" kSAN_COMMON ":exitcode=" HF_XSTR(HF_SAN_EXIT_CODE)
 /* Platform specific flags */
 #if defined(__ANDROID__)


### PR DESCRIPTION
Commit 0b418dd2 has already disabled [ODR](https://en.wikipedia.org/wiki/One_Definition_Rule) detection for honggfuzz invocations without "--sanitizers". This change does the same for when sanitizers are explicitly enabled. ODR violations aren't a concern for fuzzing, but rather for unit or integration tests.