### PR TITLE
netdriver: Add support for non-TCP protocols

### DIFF
--- a/libhfnetdriver/netdriver.h
+++ b/libhfnetdriver/netdriver.h
@@ -4,6 +4,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/socket.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,6 +22,10 @@ int HonggfuzzNetDriverArgsForServer(int argc, char** argv, int* server_argc, cha
  * TCP port that the fuzzed data inputs will be sent to
  */
 uint16_t HonggfuzzNetDriverPort(int argc, char** argv);
+/*
+ * Override target address instead of using TCP.
+ */
+int HonggfuzzNetDriverServerAddress(struct sockaddr* addr, socklen_t* addrlen);
 /*
  * Mount point for temporary filesystem
  */


### PR DESCRIPTION
Many daemons use Unix domain sockets to communicate with their clients.
This change amends libhfnetdriver with support for all
SOCK_STREAM-compatible address families while retaining the previous
behaviour of probing TCP on IPv4 and IPv6.

A newly introduced, weak-linked "HonggfuzzNetDriverServerAddress"
function allows users of the library to provide their own destination
socket address, e.g.:

```
  int HonggfuzzNetDriverServerAddress(struct sockaddr* addr,
    socklen_t* addrlen)
  {
    struct sockaddr_un saddr = {
      .sun_family = AF_UNIX,
    };
    char tempdir[PATH_MAX];

    if (HonggfuzzNetDriverTempdir(tempdir, sizeof(tempdir)) < 0) {
      return -1;
    }

    snprintf(saddr.sun_path, sizeof(saddr.sun_path), "%s/pipe",
      tempdir);

    memcpy(addr, &saddr, sizeof(saddr));
    *addrlen = sizeof(saddr);

    return 0;
  }
```

With the above function libhfnetdriver will probe the Unix socket named
"pipe" in the temporary directory provided by
"HonggfuzzNetDriverTempdir" until connections are accepted and will then
proceed to fuzz as it would a TCP connection.