### PR TITLE
Use sockaddr length from fuzzer

### DIFF
--- a/libhfnetdriver/netdriver.c
+++ b/libhfnetdriver/netdriver.c
@@ -288,7 +288,7 @@ static bool netDriver_checkIfServerReady(int argc, char **argv) {
     socklen_t slen = HonggfuzzNetDriverServerAddress(&addr);
     if (slen > 0) {
         /* User provided specific destination address */
-        int fd = netDriver_sockConnAddr(addr, sizeof(addr));
+        int fd = netDriver_sockConnAddr(addr, slen);
         if (fd >= 0) {
             close(fd);
             hfnd_globals.saddr = addr;


### PR DESCRIPTION
Commit 6814cb6a0 made major changes and introduced the
"HonggfuzzNetDriverServerAddress" function which can be defined by
a fuzzer. Unfortunately the connection attempt didn't use the
fuzzer-provided length and thus truncated longer socket address
structures such as "sockaddr_un".