### PR TITLE
netdriver: make it possible to specify both type (e.g. SOCK_DGRAM) and protocol for the destination address.

### DIFF
--- a/libhfnetdriver/netdriver.h
+++ b/libhfnetdriver/netdriver.h
@@ -35,7 +35,7 @@ int HonggfuzzNetDriverTempdir(char* str, size_t size);
  * Return 0 if only the standard connection protocols should be used (i.e. currently TCP4/TCP6 and
  * PF_UNIX via a set of standardized TCP ports (e.g. 8080) and paths)
  */
-socklen_t HonggfuzzNetDriverServerAddress(struct sockaddr** addr);
+socklen_t HonggfuzzNetDriverServerAddress(struct sockaddr_storage* addr, int* type, int* protocol);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This requires change to the HonggfuzzNetDriverServerAddress()
declaration, as it needs to enable its users to specify those two
additional params.

Additionally, pass struct sockaddr_storage to
HonggfuzzNetDriverServerAddress(), as this will prevent this func for
owning storage for the used sockaddr. It was not a bug, but this
semantics should be more familiar for C coders.