### PR TITLE
Support compilation on macOS 10.15 (Catalina)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ else ifeq ($(OS),Darwin)
     # Figure out which crash reporter to use.
     CRASHWRANGLER := third_party/mac
     OS_VERSION := $(shell sw_vers -productVersion)
-    ifneq (,$(findstring 10.14,$(OS_VERSION)))
+    ifneq (,$(findstring 10.15,$(OS_VERSION)))
+        CRASH_REPORT := $(CRASHWRANGLER)/CrashReport_Sierra.o
+    else ifneq (,$(findstring 10.14,$(OS_VERSION)))
         CRASH_REPORT := $(CRASHWRANGLER)/CrashReport_Sierra.o
     else ifneq (,$(findstring 10.13,$(OS_VERSION)))
         CRASH_REPORT := $(CRASHWRANGLER)/CrashReport_Sierra.o


### PR DESCRIPTION
Apple didn't change the CrashReporter for Catalina (verified via Apple Dev download of the zip file containing these) therefore this change should be sufficient to support 10.15.

Fixes #294