### PR TITLE
Makefile: libunwind 1.2.1 (Ubuntu 19.10) wants liblzma

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifeq ($(OS)$(findstring Microsoft,$(KERNEL)),Linux) # matches Linux but excludes
                             -lopcodes -lbfd -liberty -lz \
                             -Wl,-Bdynamic
     else
-            ARCH_LDFLAGS += -lunwind-ptrace -lunwind-generic -lunwind \
+            ARCH_LDFLAGS += -lunwind-ptrace -lunwind-generic -lunwind  -llzma \
                             -lopcodes -lbfd
     endif
     ARCH_LDFLAGS += -lrt -ldl -lm


### PR DESCRIPTION
We see

```
ld.lld: error:
/usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libunwind-ptrace.so:
undefined reference to lzma_stream_buffer_decode
```
and so forth.

The BUILD_OSSFUZZ_STATIC branch doesn't need changing because
pkgconfig adds the `-llzma`.
