### PR TITLE
Fix sort verification for blacklist entries

### DIFF
--- a/input.c
+++ b/input.c
@@ -303,7 +303,7 @@ bool input_parseBlacklist(honggfuzz_t* hfuzz) {
             hfuzz->feedback.blacklist[hfuzz->feedback.blacklistCnt]);
 
         /* Verify entries are sorted so we can use interpolation search */
-        if (hfuzz->feedback.blacklistCnt > 1) {
+        if (hfuzz->feedback.blacklistCnt >= 1) {
             if (hfuzz->feedback.blacklist[hfuzz->feedback.blacklistCnt - 1] >
                 hfuzz->feedback.blacklist[hfuzz->feedback.blacklistCnt]) {
                 LOG_F("Blacklist file not sorted. Use 'tools/createStackBlacklist.sh' to sort "


### PR DESCRIPTION
```
blacklist.txt
8
1
2
```
Honggfuzz doesn't complain this file isn't sorted, because the first entry is ignored.

```
blacklist.txt
3
2
1
```
Honggfuzz correctly warns `input_parseBlacklist():310 Blacklist file not sorted.`


The first entry gets ignored because the sorting check won't trigger until there are 2 or more entries (because the counter is updated after the comparison).

```
306 input.c:
        if (hfuzz->feedback.blacklistCnt > 1) {
            if (hfuzz->feedback.blacklist[hfuzz->feedback.blacklistCnt - 1] >
                hfuzz->feedback.blacklist[hfuzz->feedback.blacklistCnt]) {
```

The only values that will be checked for sorted order will be indexes (1) and (2) and every line higher, the index (0) is never checked.