### PR TITLE
Mutex not initialised leads to crash in MacOS for honggfuzz 2.2 while fuzzing

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -423,6 +423,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .report   = PTHREAD_MUTEX_INITIALIZER,
                 .input    = PTHREAD_MUTEX_INITIALIZER,
                 .timing   = PTHREAD_MUTEX_INITIALIZER,
+                .state   = PTHREAD_MUTEX_INITIALIZER,
             },
 
         /* Linux code */


### PR DESCRIPTION
While testing on MacOS 10.15.4, honggfuzz (latest/HEAD) crashes before completing the dry run, with the following message.
```
2020-05-03T17:02:27+0530][F][87320] util_mutexLock():280 fuzz_setDynamicMainState():95 pthread_mutex_lock(0x107c44228): Undefined error: 0
```
Initialising the `.state` variable fixes this and was able to get it running.