### PR TITLE
fix -o synonym for --output

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -550,7 +550,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
     int           opt_index = 0;
     for (;;) {
         int c = getopt_long(
-            argc, argv, "-?hQvVsuPxf:i:dqe:W:r:c:F:t:R:n:N:l:p:g:E:w:B:zMTS", opts, &opt_index);
+            argc, argv, "-?hQvVsuPxf:i:o:dqe:W:r:c:F:t:R:n:N:l:p:g:E:w:B:zMTS", opts, &opt_index);
         if (c < 0) {
             break;
         }


### PR DESCRIPTION
The `-o` argument was not working:
```
> /path/to/honggfuzz -z -P -i working-corpus/ -o hftmp -- ./target            
/home/jpereyda/code/honggfuzz/honggfuzz: invalid option -- 'o'
Usage: /home/jpereyda/code/honggfuzz/honggfuzz [options] -- path_to_command [args]
Options:
 --help|-h 
        Help plz..
[...]
```

But `--output` did work:
```
> /path/to/honggfuzz -z -P -i working-corpus/ --output hftmp -- ./target
```

After this code change, the following works:
```
> /path/to/honggfuzz -z -P -i working-corpus/ -o hftmp -- ./target
```

Root cause was a missing entry in the `optstring` argument to `getopt_long`