### PR TITLE
make --output dir if it doesn't exist, as already done with -W

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -259,6 +259,11 @@ static bool cmdlineVerify(honggfuzz_t* hfuzz) {
         return false;
     }
 
+    if (hfuzz->io.outputDir && mkdir(hfuzz->io.outputDir, 0700) == -1 && errno != EEXIST) {
+        PLOG_E("Couldn't create the output directory '%s'", hfuzz->io.outputDir);
+        return false;
+    }
+
     if (strlen(hfuzz->io.workDir) == 0) {
         if (getcwd(hfuzz->io.workDir, sizeof(hfuzz->io.workDir)) == NULL) {
             PLOG_W("getcwd() failed. Using '.'");


### PR DESCRIPTION
Running honggfuzz with -o and -W where neither directory exists:
```
> ls | grep hftmp
> /path/honggfuzz -z -P -i working-corpus/ --output hftmpo -W hftmpW -- ./target
[...]
[2020-05-07T09:47:51-0700][F][11897] main():331 Output directory 'hftmpo' is not writeable: No such file or directory
> ls | grep hftmp
hftmpW
```

Only the -W directory is created.

After code change:
```
> ls | grep hftmp
> /path/to/honggfuzz -z -P -i working-corpus/ -o hftmpo -W hftmpW -- ./target
[...fuzzing output...]
> ls | grep hftmp
hftmpo
hftmpW
```
