### PR TITLE
dockerfile: set noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:rolling
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get -y update && apt-get install -y \
     gcc \
     git \


### PR DESCRIPTION
This stops tzdata asking you to enter timezones and things.