### PR TITLE
add chose when tcp server not return anything

### DIFF
--- a/libhfnetdriver/netdriver.c
+++ b/libhfnetdriver/netdriver.c
@@ -32,7 +32,7 @@ const char *const LIBHFNETDRIVER_module_netdriver = _HF_NETDRIVER_SIG;
 #define HFND_TCP_PORT_ENV     "HFND_TCP_PORT"
 #define HFND_SOCK_PATH_ENV    "HFND_SOCK_PATH"
 #define HFND_SKIP_FUZZING_ENV "HFND_SKIP_FUZZING"
-
+//# define NORECVTIME            10
 static char *initial_server_argv[] = {"fuzzer", NULL};
 
 static struct {
@@ -436,9 +436,20 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
      * TCP server to drop the input data, instead of processing it. Use BSS to avoid putting
      * pressure on the stack size
      */
+#ifdef NORECVTIME
+    struct timeval timeout={1,0};//1s
+    setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,&timeout,sizeof(timeout));
+    clock_t start,end;
+    start = clock();
+#endif				 
     static char b[1024ULL * 1024ULL * 4ULL];
-    while (TEMP_FAILURE_RETRY(recv(sock, b, sizeof(b), MSG_WAITALL)) > 0)
-        ;
+    while (TEMP_FAILURE_RETRY(recv(sock, b, sizeof(b), MSG_WAITALL)) > 0){
+#ifdef NORECVTIME
+        end= clock();
+        if(  ((double)end-start)/CLK_TCK>NORECVTIME)
+            break;
+#endif						 
+    }
 
     close(sock);
 


### PR DESCRIPTION
Some tcp server don`t return anything ,but not crash.The tcp server will restart again and again,and it spend a lot of time.So I add a macro(Default off) to adapt to this situation


