### PR TITLE
Improve NetBSD compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,9 +368,12 @@ install: all
 	install -m 755 hfuzz_cc/hfuzz-clang++ $${DESTDIR}$(BIN_PATH)
 	install -m 755 hfuzz_cc/hfuzz-gcc $${DESTDIR}$(BIN_PATH)
 	install -m 755 hfuzz_cc/hfuzz-g++ $${DESTDIR}$(BIN_PATH)
-	install -m 755 -t $${DESTDIR}$(INC_PATH)/libhfcommon -D includes/libhfcommon/*.h
-	install -m 755 -t $${DESTDIR}$(INC_PATH)/libhfuzz -D includes/libhfuzz/*.h
-	install -m 755 -t $${DESTDIR}$(INC_PATH)/libhnetdriver -D includes/libhfnetdriver/*.h
+	install -d $${DESTDIR}$(INC_PATH)/libhfcommon
+	install -d $${DESTDIR}$(INC_PATH)/libhfuzz
+	install -d $${DESTDIR}$(INC_PATH)/libhnetdrive
+	install -m 755 includes/libhfcommon/*.h $${DESTDIR}$(INC_PATH)/libhfcommon
+	install -m 755 includes/libhfuzz/*.h $${DESTDIR}$(INC_PATH)/libhfuzz
+	install -m 755 includes/libhfnetdriver/*.h $${DESTDIR}$(INC_PATH)/libhnetdriver
 
 # DO NOT DELETE
 


### PR DESCRIPTION
Stop using install -t as it is GNU specific. Replace it with a
portable construct.

Before reading with ptrace(2) from address 0x0, check whether
the VA0 is mappable into the process, as otherwise the ptrace(2)
call will return EINVAL.

Stop intercepting fork(2) events as they are ignored anyway.

Document PTRACE_POSIX_SPAWN events.

Use PT_SET_SIGPASS to disable notifying the parent about
uninteresting signals. The only interesting ones are crash signals,
SIGABRT and SIGSYS. Everything else is directly passed to the
traced process.