### PR TITLE
faster util_32bitValInBinary/util_64bitValInBinary

### DIFF
--- a/libhfcommon/util.h
+++ b/libhfcommon/util.h
@@ -189,7 +189,7 @@ extern void util_closeStdio(bool close_stdin, bool close_stdout, bool close_stde
 
 extern lhfc_addr_t util_getProgAddr(const void* addr);
 extern bool        util_32bitValInBinary(uint32_t v);
-extern bool        util_64bitValInBinary(uint32_t v);
+extern bool        util_64bitValInBinary(uint64_t v);
 
 extern uint64_t util_hash(const char* buf, size_t len);
 extern int64_t  fastArray64Search(uint64_t* array, size_t arraySz, uint64_t key);


### PR DESCRIPTION
This PR is related to #345 

It's still WIP....

I use libxml2 for test, and use `-F 1` to make a comparable test (Intel(R) Core(TM) i7-8750H CPU):
./honggfuzz -i in -F 1 -t 10 -- ./examples/libxml2/before_patch speed: about 15000 to 17000/s
./honggfuzz -i in -F 1 -t 10 -- ./examples/libxml2/after_patch speed: about 21000 to 22000/s

and in single thread mod, it has much more improvement
./honggfuzz -i in -F 1 -t 10 -n 1 -- ./examples/libxml2/before_patch speed: about 4500/s
./honggfuzz -i in -F 1 -t 10 -n 1-- ./examples/libxml2/after_patch speed: about 8000 to 8500/s

The basic Idea is to not scan binary each time, but use a binary search way to determine if a value exists in the binary....

Becasue It need a time-consuming initialize stage to get `sorted values of binary`... So it's only suitable for persistent mode...

Do you have any ideas about where should I start to make this idea work with fork-mode？@robertswiecki
