### PR TITLE
randomize instrumentLimitEvery

### DIFF
--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -233,10 +233,7 @@ void instrumentResetLocalCovFeedback(void) {
 
 /* Used to limit certain expensive actions, like adding values to dictionaries */
 static inline bool instrumentLimitEvery(uint64_t step) {
-    static __thread uint64_t staticCnt = 0;
-    if (((staticCnt++) % step) == 0) {
-        return true;
-    }
+    if (util_rndGet(0, step) == 0) return true;
     return false;
 }
 


### PR DESCRIPTION
If we run in fork-and-exec mode, `staticCnt` will starts
from zero for each run. So for example `__sanitizer_cov_trace_cmp4` will
only be executed at the 4096th time...

If the target is small to have 4096 cmp during execution,
`__sanitizer_cov_trace_cmp4` trick will never work.
Even if the target is big, `instrumentLimitEvery` is may still biased....

So I just make it random..