### PR TITLE
Remove redundant F_SETSIG call from process fork

### DIFF
--- a/linux/arch.c
+++ b/linux/arch.c
@@ -183,9 +183,6 @@ void arch_prepareParentAfterFork(run_t* run) {
         if (fcntl(run->persistentSock, F_SETOWN_EX, &fown)) {
             PLOG_F("fcntl(%d, F_SETOWN_EX)", run->persistentSock);
         }
-        if (fcntl(run->persistentSock, F_SETSIG, SIGIO) == -1) {
-            PLOG_F("fcntl(%d, F_SETSIG, SIGIO)", run->persistentSock);
-        }
         if (fcntl(run->persistentSock, F_SETFL, O_ASYNC) == -1) {
             PLOG_F("fcntl(%d, F_SETFL, O_ASYNC)", run->persistentSock);
         }


### PR DESCRIPTION
Setting the signal on a file descriptor to SIGIO should be redundant, according to the POSIX specification. Moreover, this system call currently prevents Honggfuzz from running inside a gVisor sandbox.