### PR TITLE
Fix socket fuzzer

### DIFF
--- a/fuzz.c
+++ b/fuzz.c
@@ -478,7 +478,7 @@ static void* fuzz_threadNew(void* arg) {
     run_t run = {
         .global         = hfuzz,
         .pid            = 0,
-        .dynfile        = (dynfile_t*)util_Malloc(sizeof(dynfile_t) + hfuzz->io.maxFileSz),
+        .dynfile        = (dynfile_t*)util_Calloc(sizeof(dynfile_t) + hfuzz->io.maxFileSz),
         .fuzzNo         = fuzzNo,
         .persistentSock = -1,
         .tmOutSignaled  = false,

--- a/socketfuzzer/README.md
+++ b/socketfuzzer/README.md
@@ -59,7 +59,7 @@ Start hongfuzz in socket-client mode:
 $ cd ~/honggfuzz
 $ mkdir test
 $ cd test
-$ ../honggfuzz --keep_output --debug --sanitizers --sancov --stdin_input --threads 1 --verbose --logfile log.txt --socket_fuzzer -- ../socketfuzzer/vulnserver_cov
+$ ../honggfuzz --keep_output --debug --sanitizers --stdin_input --threads 1 --verbose --logfile log.txt --socket_fuzzer -- ../socketfuzzer/vulnserver_cov
 Waiting for SocketFuzzer connection on socket: /tmp/honggfuzz_socket.<pid>
 ```
 


### PR DESCRIPTION
The specific problem I was running into is that the socket fuzzer was running out of memory when *dynfile->data* was being allocated in *input_addDynamicInput* as *run->dynfile->size* was whatever had been on heap. (There's likely other good reasons to initialize the memory though.)

In addition, remove *--sancov* from the documentation as it's been removed from the code.