### PR TITLE
Custom mutator feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BIN := honggfuzz
 HFUZZ_CC_BIN := hfuzz_cc/hfuzz-cc
 HFUZZ_CC_SRCS := hfuzz_cc/hfuzz-cc.c
 COMMON_CFLAGS := -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I.
-COMMON_LDFLAGS := -pthread -lm
+COMMON_LDFLAGS := -pthread -lm -ldl
 COMMON_SRCS := $(sort $(wildcard *.c))
 CFLAGS ?= -O3 -mtune=native -funroll-loops
 LDFLAGS ?=

--- a/cmdline.c
+++ b/cmdline.c
@@ -519,6 +519,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "only_printable", no_argument, NULL, 0x10D }, "Only generate printable inputs" },
         { { "export_feedback", no_argument, NULL, 0x10E }, "Export the coverage feedback structure as ./hfuzz-feedback" },
         { { "const_feedback", required_argument, NULL, 0x112 }, "Use constant integer/string values from fuzzed programs to mangle input files via a dynamic dictionary (default: true)" },
+        { { "custom_mutator", required_argument, NULL, 0x113 }, "Custom mutator" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blacklist filter file (one entry per line)" },
@@ -777,6 +778,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 hfuzz->arch_netbsd.symsWlFile = optarg;
                 break;
 #endif /* defined(_HF_ARCH_NETBSD) */
+            case 0x113:
+                hfuzz->mutate.customMutatorFileName = optarg;
+                break;
             default:
                 cmdlineUsage(argv[0], custom_opts);
                 return false;

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -111,6 +111,8 @@ static const uint8_t HFReadyTag = 'R';
 /* printf() nonmonetary separator. According to MacOSX's man it's supported there as well */
 #define _HF_NONMON_SEP "'"
 
+typedef void (*customMutator_t)(uint8_t data[], size_t size);
+
 typedef enum {
     _HF_DYNFILE_NONE         = 0x0,
     _HF_DYNFILE_INSTR_COUNT  = 0x1,
@@ -253,6 +255,9 @@ typedef struct {
         size_t      mutationsMax;
         unsigned    mutationsPerRun;
         size_t      maxInputSz;
+        const char* customMutatorFileName;
+        void*       customMutatorLibHandler;
+        customMutator_t customMutatorFunction;
     } mutate;
     struct {
         bool    useScreen;

--- a/mangle.c
+++ b/mangle.c
@@ -812,6 +812,13 @@ static void mangle_Resize(run_t* run, bool printable) {
     }
 }
 
+static void mangle_Custom(run_t* run, bool printable HF_ATTR_UNUSED) {
+    if (run->global->mutate.customMutatorFunction) {
+        LOG_D("Running custom mutator...");
+        run->global->mutate.customMutatorFunction(run->dynfile->data, run->dynfile->size);
+    }
+}
+
 void mangle_mangleContent(run_t* run, int speed_factor) {
     static void (*const mangleFuncs[])(run_t * run, bool printable) = {
         /* Every *Insert or Expand expands file, so add more Shrink's */
@@ -846,6 +853,13 @@ void mangle_mangleContent(run_t* run, int speed_factor) {
     }
     if (run->dynfile->size == 0U) {
         mangle_Resize(run, /* printable= */ run->global->cfg.only_printable);
+    }
+
+    /* Custom mutator. */
+    if (run->global->mutate.customMutatorFunction) {
+        mangle_Custom(run, /* printable= */ run->global->cfg.only_printable);
+        wmb();
+        return;
     }
 
     uint64_t changesCnt = run->global->mutate.mutationsPerRun;


### PR DESCRIPTION
Hi! Here is a patch that may be useful for others.

Honggfuzz offers a way to plug an external mutator, the `--mutate_cmd` command-line option. The main drawback of this approach is its cost. Honggfuzz creates a new process each time it invokes the external mutator.

This patch addresses this issue. It adds a new option: `--custom_mutator <SHARED-OBJECT>`. When this option is present, Honggfuzz will call the mutator passed as parameter. The performance achieved with this new patch is the same as the Honggfuzz's internal mutators since there is no need to create a new process.

The mutator has to export a function called `custom_mutator` with the following prototype:

```c
void custom_mutator(uint8_t *buf, size_t len);
```

NOTE: Tested on Ubuntu.