### PR TITLE
Log stats to disk

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -519,6 +519,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "only_printable", no_argument, NULL, 0x10D }, "Only generate printable inputs" },
         { { "export_feedback", no_argument, NULL, 0x10E }, "Export the coverage feedback structure as ./hfuzz-feedback" },
         { { "const_feedback", required_argument, NULL, 0x112 }, "Use constant integer/string values from fuzzed programs to mangle input files via a dynamic dictionary (default: true)" },
+        { { "statsfile", required_argument, NULL, 0x114 }, "Stats file" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blacklist filter file (one entry per line)" },
@@ -777,6 +778,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 hfuzz->arch_netbsd.symsWlFile = optarg;
                 break;
 #endif /* defined(_HF_ARCH_NETBSD) */
+            case 0x114:
+                hfuzz->io.statsFileName = optarg;
+                break;
             default:
                 cmdlineUsage(argv[0], custom_opts);
                 return false;

--- a/fuzz.c
+++ b/fuzz.c
@@ -229,6 +229,39 @@ static void fuzz_perfFeedback(run_t* run) {
             softNewPC, softNewCmp, run->hwCnts.cpuInstrCnt, run->hwCnts.cpuBranchCnt,
             run->hwCnts.bbCnt, softCurEdge, softCurPC, softCurCmp);
 
+        if (run->global->io.statsFileName) {
+            /* NOTE: Calculation of `tot_exec_per_sec` taken from
+             * the `display_display` function.
+             */
+            const time_t curr_sec = time(NULL);
+            const time_t elapsed_sec = curr_sec - run->global->timing.timeStart;
+            size_t curr_exec_cnt = ATOMIC_GET(run->global->cnts.mutationsCnt);
+            /*
+             * We increase the mutation counter unconditionally in threads, but if it's
+             * above hfuzz->mutationsMax we don't really execute the fuzzing loop.
+             * Therefore at the end of fuzzing, the mutation counter might be higher
+             * than hfuzz->mutationsMax
+             */
+            if (run->global->mutate.mutationsMax > 0 && curr_exec_cnt > run->global->mutate.mutationsMax) {
+                curr_exec_cnt = run->global->mutate.mutationsMax;
+            }
+            size_t tot_exec_per_sec = elapsed_sec ? (curr_exec_cnt / elapsed_sec) : 0;
+
+            dprintf(run->global->io.statsFileFd,
+                "%lu, %lu, %lu, %lu, "
+                "%" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n",
+                curr_sec,                                               /* unix_time */
+                ATOMIC_GET(run->global->timing.lastCovUpdate),          /* last_cov_update */
+                curr_exec_cnt,                                          /* total_exec */
+                tot_exec_per_sec,                                       /* exec_per_sec */
+                ATOMIC_GET(run->global->cnts.crashesCnt),               /* crashes */
+                ATOMIC_GET(run->global->cnts.uniqueCrashesCnt),         /* unique_crashes */
+                ATOMIC_GET(run->global->cnts.timeoutedCnt),             /* hangs */
+                ATOMIC_GET(run->global->feedback.hwCnts.softCntEdge),   /* edge */
+                ATOMIC_GET(run->global->feedback.hwCnts.softCntPc)      /* pc */
+            );
+        }
+
         /* Update per-input coverage metrics */
         run->dynfile->cov[0] = softCurEdge + softCurPC + run->hwCnts.bbCnt;
         run->dynfile->cov[1] = softCurCmp;

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -23,12 +23,14 @@
  */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -394,6 +396,16 @@ int main(int argc, char** argv) {
                 sizeof(cmpfeedback_t), hfuzz.io.workDir);
         }
     }
+    /* Stats file. */
+    if (hfuzz.io.statsFileName) {
+        hfuzz.io.statsFileFd = TEMP_FAILURE_RETRY(open(hfuzz.io.statsFileName, O_CREAT | O_RDWR | O_TRUNC, 0640));
+
+        if (hfuzz.io.statsFileFd == -1) {
+            PLOG_F("Couldn't open statsfile open('%s')", hfuzz.io.statsFileName);
+        } else {
+            dprintf(hfuzz.io.statsFileFd, "# unix_time, last_cov_update, total_exec, exec_per_sec, crashes, unique_crashes, hangs, edge, pc\n");
+        }
+    }
 
     setupRLimits();
     setupSignalsPreThreads();
@@ -427,6 +439,10 @@ int main(int argc, char** argv) {
 #endif
     if (hfuzz.socketFuzzer.enabled) {
         cleanupSocketFuzzer();
+    }
+    /* Stats file. */
+    if (hfuzz.io.statsFileName) {
+        close(hfuzz.io.statsFileFd);
     }
 
     printSummary(&hfuzz);

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -214,6 +214,8 @@ typedef struct {
         dynfile_t*  dynfileq2Current;
         TAILQ_HEAD(dyns_t, _dynfile_t) dynfileq;
         bool exportFeedback;
+        const char* statsFileName;
+        int         statsFileFd;
     } io;
     struct {
         int                argc;


### PR DESCRIPTION
Hi! Here's a small patch to log some of the stats to disk that may be useful to others.

It adds a new command line option: `--statsfile <FILENAME>`. It logs the following data in CSV format:

```csv
unix_time, last_cov_update, total_exec, exec_per_sec, crashes, unique_crashes, hangs, edge, pc
```

The logging is done every time new coverage is found.