### PR TITLE
allow --save-smaller to overwrite

### DIFF
--- a/linux/trace.c
+++ b/linux/trace.c
@@ -543,6 +543,7 @@ static void arch_traceSaveData(run_t* run, pid_t pid) {
         crashAddr = 0UL;
     }
 
+    int open_flags = O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC;
     uint64_t pc         = 0;
     uint64_t status_reg = 0;
     size_t   pcRegSz    = arch_getPC(pid, &pc, &status_reg);
@@ -729,6 +730,9 @@ static void arch_traceSaveData(run_t* run, pid_t pid) {
             snprintf(origFile, sizeof(origFile), "%s.orig", run->crashFileName);
             if (!files_exists(origFile)) {
                 rename(run->crashFileName, origFile);
+            } else {
+                    /* allow overwrite */
+                open_flags =  O_CREAT | O_WRONLY | O_CLOEXEC;
             }
         } else {
             LOG_I("Crash (dup): '%s' already exists, skipping", run->crashFileName);
@@ -739,7 +743,7 @@ static void arch_traceSaveData(run_t* run, pid_t pid) {
     }
 
     if (!files_writeBufToFile(run->crashFileName, run->dynfile->data, run->dynfile->size,
-            O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC)) {
+            open_flags)) {
         LOG_E("Couldn't write to '%s'", run->crashFileName);
         return;
     }


### PR DESCRIPTION
Previously we would save the first smaller file, but not the second
and subsequent ones.
