### PR TITLE
android target under OSX / android aarch64 libunwind patches

### DIFF
--- a/third_party/android/patches/libunwind.patch
+++ b/third_party/android/patches/libunwind.patch
@@ -188,7 +188,7 @@ index 6379d8e..8222c02 100644
    return 0;
  }
 diff --git a/src/ptrace/_UPT_access_fpreg.c b/src/ptrace/_UPT_access_fpreg.c
-index e90ec47..50a4c25 100644
+index e90ec47d..ae61d093 100644
 --- a/src/ptrace/_UPT_access_fpreg.c
 +++ b/src/ptrace/_UPT_access_fpreg.c
 @@ -46,8 +46,8 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
@@ -202,7 +202,7 @@ index e90ec47..50a4c25 100644
  #endif
          if (errno)
            return -UNW_EBADREG;
-@@ -59,7 +59,7 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
+@@ -59,14 +59,14 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
  #       warning No support for ttrace() yet.
  #else
          wp[i] = ptrace (PTRACE_PEEKUSER, pid,
@@ -211,6 +211,14 @@ index e90ec47..50a4c25 100644
  #endif
          if (errno)
            return -UNW_EBADREG;
+       }
+   return 0;
+ }
+-#elif HAVE_DECL_PT_GETFPREGS
++#elif HAVE_DECL_PT_GETFPREGS && !defined(__aarch64__)
+ int
+ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
+                    int write, void *arg)
 @@ -100,6 +100,14 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
  #endif
    return 0;

--- a/third_party/android/scripts/compile-capstone.sh
+++ b/third_party/android/scripts/compile-capstone.sh
@@ -111,8 +111,8 @@ ANDROID_API_V=$(echo "$ANDROID_API" | grep -oE '[0-9]{1,2}$')
 HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH=$(uname -m)
 
-export CC="$NDK"/toolchains/llvm/prebuilt/linux-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang
-export CXX="$NDK"/toolchains/llvm/prebuilt/linux-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang++
+export CC="$NDK"/toolchains/llvm/prebuilt/"$HOST_OS"-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang
+export CXX="$NDK"/toolchains/llvm/prebuilt/"$HOST_OS"-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang++
 
 # Build it
 make clean

--- a/third_party/android/scripts/compile-libunwind.sh
+++ b/third_party/android/scripts/compile-libunwind.sh
@@ -119,8 +119,8 @@ HOST_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH=$(uname -m)
 
 
-export CC="$NDK"/toolchains/llvm/prebuilt/linux-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang
-export CXX="$NDK"/toolchains/llvm/prebuilt/linux-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang++
+export CC="$NDK"/toolchains/llvm/prebuilt/"$HOST_OS"-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang
+export CXX="$NDK"/toolchains/llvm/prebuilt/"$HOST_OS"-x86_64/bin/"$ANDROID_NDK_COMPILER_PREFIX""$ANDROID_API_V"-clang++
 
 if [ ! -x "$CC" ]; then
   echo "[-] clang doesn't exist: $CC"


### PR DESCRIPTION
This PR fixes the following:

- android build of libunwind and libcapstone under OSX would fail due to hardcoded "linux" in toolchain path (#381)
- libunwind with ptrace enabled for android/aarch64 would fail during runtime for the following reasons:
   1. `HAVE_DECL_PTRACE_POKEUSER` was enabled while `HAVE_DECL_PT_GETREGSET` was disabled. This would cause `unw_init_remote` to return `EBADREG`, as a result making every crash appear unique when it clearly wasn't. This config was correct in previous versions of honggfuzz (file: compile-libunwind.sh) but was removed in ac7df4eddcbf10a870e94933e13405544550bac4 
   2. Preprocessor branch on `HAVE_DECL_PT_GETFPREGS` (file src/ptrace/_UPT_access_fpreg.c) did not properly exclude __aarch64__ resulting in the wrong implementation of `_UPT_access_fpreg` being compiled in.