### PR TITLE
Fix default/debug build with Bazel on OSX

### DIFF
--- a/libhfcommon/log.h
+++ b/libhfcommon/log.h
@@ -26,6 +26,11 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#ifdef _HF_ARCH_DARWIN
+#pragma push_macro("DEBUG")
+#undef DEBUG
+#endif
+
 enum llevel_t { FATAL = 0, ERROR, WARNING, INFO, DEBUG, HELP, HELP_BOLD };
 
 extern enum llevel_t hf_log_level;
@@ -91,5 +96,9 @@ extern enum llevel_t logGetLevel(void);
 extern pthread_mutex_t* logMutexGet(void);
 
 void logMutexReset(void);
+
+#ifdef _HF_ARCH_DARWIN
+#pragma pop_macro("DEBUG")
+#endif
 
 #endif /* ifndef _HF_COMMON_LOG_H_ */


### PR DESCRIPTION
For debug / fastbuild (default) Bazel defines `DEBUG` on OSX.

This is somewhat legacy, but Bazel developers consider that "works as intended".

Without this fix `bazelbuild / rules_fuzzing` project does not build on OSX.