### PR TITLE
Fix build in CentOS 7

### DIFF
--- a/linux/trace.c
+++ b/linux/trace.c
@@ -542,7 +542,12 @@ static void arch_traceAnalyzeData(run_t* run, pid_t pid) {
 
 static void arch_traceSaveData(run_t* run, pid_t pid) {
     char      instr[_HF_INSTR_SZ] = "\x00";
+#if defined(__GNUC__) && ((__GNUC__ < 5) || (__GNUC__ == 5 && __GNUC_MINOR__ < 1))
+    siginfo_t si;
+    bzero(&si, sizeof(si));
+#else
     siginfo_t si                  = {};
+#endif
 
     if (ptrace(PTRACE_GETSIGINFO, pid, 0, &si) == -1) {
         PLOG_W("Couldn't get siginfo for pid %d", pid);


### PR DESCRIPTION
CentOS 7 uses gcc 4.8.5, which fails to build with the following error

```
linux/trace.c: In function 'arch_traceSaveData':
linux/trace.c:545:5: error: missing initializer for field 'si_signo' of 'siginfo_t' [-Werror=missing-field-initializers]
     siginfo_t si                  = {};
     ^
In file included from /usr/include/signal.h:80:0,
                 from ./honggfuzz.h:31,
                 from ./linux/trace.h:29,
                 from linux/trace.c:24:
/usr/include/bits/siginfo.h:64:9: note: 'si_signo' declared here
     int si_signo;  /* Signal number.  */
         ^
linux/trace.c: At top level:
cc1: error: unrecognized command line option "-Wno-format-truncation" [-Werror]
cc1: all warnings being treated as errors
make: *** [linux/trace.o] Error 1
```
This MR detects this old version and initializes the struct accordingly