### PR TITLE
Fix clang diagnostic pragma.

### DIFF
--- a/linux/trace.c
+++ b/linux/trace.c
@@ -232,8 +232,8 @@ struct user_regs_struct {
 #endif /* defined(__ANDROID__) */
 
 #if defined(__clang__)
-_Pragma("clang Diagnostic push\n");
-_Pragma("clang Diagnostic ignored \"-Woverride-init\"\n");
+_Pragma("clang diagnostic push");
+_Pragma("clang diagnostic ignored \"-Woverride-init\"");
 #endif
 
 static struct {


### PR DESCRIPTION
Fix break when building with clang.

```
$ CC=clang make
clang -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -Wno-initializer-overrides -Wno-unknown-warning-option -Wno-gnu-empty-initializer -Wno-format-pedantic -Wno-gnu-statement-expression -mllvm -in
line-threshold=2000 -D_HF_ARCH_LINUX -fblocks -o linux/trace.o linux/trace.c
linux/trace.c:235:1: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
_Pragma("clang Diagnostic push\n");
^
<scratch space>:236:8: note: expanded from here
 clang Diagnostic push\n
       ^
linux/trace.c:236:1: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
_Pragma("clang Diagnostic ignored \"-Woverride-init\"\n");
^
<scratch space>:238:8: note: expanded from here
 clang Diagnostic ignored "-Woverride-init"\n
       ^
linux/trace.c:274:1: error: pragma diagnostic pop could not pop, no matching push [-Werror,-Wunknown-pragmas]
_Pragma("clang diagnostic pop");
^
<scratch space>:240:19: note: expanded from here
 clang diagnostic pop
                  ^
3 errors generated.
make: *** [Makefile:263: linux/trace.o] Error 1
```