### PR TITLE
Fix the bug of globalCmpFeedback

### DIFF
--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -123,6 +123,7 @@ static void initializeCmpFeedback(void) {
             _HF_CMP_BITMAP_FD, sizeof(cmpfeedback_t));
         return;
     }
+    memset(ret, 0, sizeof(cmpfeedback_t));
     ATOMIC_SET(globalCmpFeedback, ret);
 }
 


### PR DESCRIPTION
Fixed the crash problem caused by not initialized when applying for globalCmpFeedback memory. Invalid test cases will be generated due to the crash in the program being tested.