### PR TITLE
Always build against libiberty and libz on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(OS)$(findstring Microsoft,$(KERNEL)),Linux) # matches Linux but excludes
                             -Wl,-Bdynamic
     else
             ARCH_LDFLAGS += -lunwind-ptrace -lunwind-generic -lunwind  -llzma \
-                            -lopcodes -lbfd
+                            -lopcodes -lbfd -liberty -lz
     endif
     ifeq ($(BUILD_LINUX_NO_BFD),true)
             ARCH_CFLAGS += -D_HF_LINUX_NO_BFD


### PR DESCRIPTION
Hi!

When I try to build honggfuzz from master, I get undefined symbols errors:

<details>
<summary>Make output</summary>

```
honggfuzz on  master
❯ make
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o cmdline.o cmdline.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o display.o display.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o fuzz.o fuzz.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o honggfuzz.o honggfuzz.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o input.o input.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o mangle.o mangle.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o report.o report.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o sanitizers.o sanitizers.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o socketfuzzer.o socketfuzzer.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o subproc.o subproc.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o linux/arch.o linux/arch.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o linux/bfd.o linux/bfd.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o linux/perf.o linux/perf.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o linux/pt.o linux/pt.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o linux/trace.o linux/trace.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -o linux/unwind.o linux/unwind.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfcommon/files.o libhfcommon/files.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfcommon/log.o libhfcommon/log.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfcommon/ns.o libhfcommon/ns.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfcommon/util.o libhfcommon/util.c
ar rcs libhfcommon/libhfcommon.a libhfcommon/files.o libhfcommon/log.o libhfcommon/ns.o libhfcommon/util.o
cc -o honggfuzz cmdline.o display.o fuzz.o honggfuzz.o input.o mangle.o report.o sanitizers.o socketfuzzer.o subproc.o linux/arch.o linux/bfd.o linux/perf.o linux/pt.o linux/trace.o linux/unwind.o libhfcommon/libhfcommon.a -pthread -lm -L/usr/local/include -lunwind-ptrace -lunwind-generic -lunwind  -llzma -lopcodes -lbfd -lrt -ldl -lm
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(i386-dis.o): in function `putop':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/i386-dis.c:10331: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(aarch64-opc.o): in function `init_insn_sequence':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/aarch64-opc.c:5104: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/aarch64-opc.c:5122: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(arm-dis.o): in function `print_insn_neon':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:9387: undefined reference to `floatformat_ieee_single_little'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:9387: undefined reference to `floatformat_to_double'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(arm-dis.o): in function `print_simd_imm8':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:7076: undefined reference to `floatformat_ieee_single_little'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:7076: undefined reference to `floatformat_to_double'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(arm-dis.o): in function `disassembler_options_arm':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:12330: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:12334: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/arm-dis.c:12335: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(epiphany-dis.o): in function `print_insn_epiphany':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-dis.c:683: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(ia64-opc.o): in function `make_ia64_opcode':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/ia64-opc.c:533: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/ia64-opc.c:534: undefined reference to `xstrdup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(m68k-dis.o): in function `print_insn_arg':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1115: undefined reference to `floatformat_m68881_ext'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1115: undefined reference to `floatformat_to_double'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1107: undefined reference to `floatformat_ieee_single_big'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1107: undefined reference to `floatformat_to_double'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1111: undefined reference to `floatformat_ieee_double_big'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1111: undefined reference to `floatformat_to_double'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(m68k-dis.o): in function `m68k_scan_mask':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/m68k-dis.c:1518: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(mips-dis.o): in function `disassembler_options_mips':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/mips-dis.c:2716: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/mips-dis.c:2720: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/mips-dis.c:2728: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/mips-dis.c:2739: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(mips-dis.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/mips-dis.c:2743: more undefined references to `xmalloc' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-opc.o): in function `hash_keyword_name':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:217: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-opc.o): in function `cgen_keyword_add':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:125: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-opc.o): in function `build_keyword_hash_tables':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:244: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:247: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:244: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:247: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-opc.o): in function `hash_keyword_name':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:217: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-opc.o): in function `cgen_keyword_lookup_name':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:65: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:65: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-opc.o): in function `cgen_lookup_insn':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-opc.c:462: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(epiphany-asm.o): in function `parse_insn_normal':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:639: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:675: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:726: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(epiphany-asm.o): in function `epiphany_cgen_build_insn_regex':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:500: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:525: undefined reference to `_sch_toupper'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:524: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:555: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:558: undefined reference to `_sch_tolower'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:559: undefined reference to `_sch_toupper'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:586: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:587: undefined reference to `xregcomp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:595: undefined reference to `xregerror'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:596: undefined reference to `xregfree'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(epiphany-asm.o): in function `epiphany_cgen_assemble_insn':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:774: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-asm.c:805: undefined reference to `xregexec'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-x86-64.o): in function `elf_x86_64_output_arch_local_syms':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-x86-64.c:4780: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-x86.o): in function `elf_x86_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:686: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:688: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-x86.o): in function `_bfd_elf_x86_get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:574: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:587: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-x86.o): in function `_bfd_x86_elf_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:765: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:769: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-x86.o): in function `elf_x86_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:686: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:688: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-x86.o): in function `_bfd_x86_elf_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-x86.c:1202: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elflink.o): in function `elf_link_add_object_symbols':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elflink.c:5449: undefined reference to `objalloc_free_block'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elflink.c:5698: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elflink.o): in function `bfd_elf_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elflink.c:6908: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elflink.c:6681: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elflink.o): in function `elf_link_input_bfd':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elflink.c:11019: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(pei-x86_64.o): in function `pex64_bfd_print_pdata_section':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pei-x86_64.c:622: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pei-x86_64.c:698: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-aarch64.o): in function `elf64_aarch64_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2887: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2889: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-aarch64.o): in function `elf64_aarch64_get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2802: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2815: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-aarch64.o): in function `elf64_aarch64_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2930: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2934: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-aarch64.o): in function `elf64_aarch64_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2887: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2889: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-aarch64.o): in function `elf64_aarch64_finish_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:9749: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-aarch64.o): in function `elf64_aarch64_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:8998: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-arm.o): in function `elf32_arm_get_stub_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-arm.c:4588: undefined reference to `xexit'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-arm.o): in function `add_unwind_table_edit':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-arm.c:13446: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-arm.c:13446: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-arm.c:13446: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ia64.o): in function `elf64_ia64_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1436: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1438: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1441: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ia64.o): in function `elf64_ia64_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1469: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1471: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ia64.o): in function `get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1598: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1608: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ia64.o): in function `elf64_ia64_dyn_sym_traverse':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1541: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1541: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1541: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1541: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1541: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ia64.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-ia64.c:1541: more undefined references to `htab_traverse' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_get_got_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1584: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1572: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1584: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_clear_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1435: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_finalize_got_offsets':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:2250: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:2250: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:960: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_get_bfd2got_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1822: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1811: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1822: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_can_merge_gots':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1966: undefined reference to `htab_traverse_noresize'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_clear_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1435: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_merge_gots':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:2040: undefined reference to `htab_traverse_noresize'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_clear_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1435: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:1435: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-m68k.o): in function `elf_m68k_partition_multi_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-m68k.c:2474: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_create_got_info':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3173: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3178: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_add_got_page_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4606: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_resolve_final_got_entries':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4462: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4466: undefined reference to `htab_size'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4466: undefined reference to `htab_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4472: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4476: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4479: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4486: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_replace_bfd_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3216: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3217: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3219: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_merge_got_with':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4659: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4663: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_record_got_page_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4288: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_add_got_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4580: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_recreate_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4242: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4242: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_create_stub_symbol':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:1641: undefined reference to `concat'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:1641: undefined reference to `concat'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_record_got_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3987: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4010: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_create_shadow_symbol':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:1683: undefined reference to `concat'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_add_la25_stub':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:1996: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_add_la25_intro':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:1909: undefined reference to `htab_elements'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_create_local_got_entry':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3774: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3786: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `_bfd_mips_elf_init_stubs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:1840: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_lay_out_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:9694: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_multi_got':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4955: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4957: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:5001: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:5012: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:5030: more undefined references to `htab_traverse' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_global_got_index':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:3623: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `_bfd_mips_elf_finish_dynamic_symbol':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:11248: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `mips_elf_record_got_page_ref':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4121: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:4141: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-mips.o): in function `_bfd_mips_elf_final_link':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-mips.c:14736: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ppc.o): in function `ppc64_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-ppc.c:3462: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ppc.o): in function `tocsave_find':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-ppc.c:6935: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ppc.o): in function `ppc64_elf_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-ppc.c:3505: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-ppc.o): in function `ppc64_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-ppc.c:3462: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:379: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:381: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_elf_finish_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:3285: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_record_pcrel_hi_reloc':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1866: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_elf_get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:344: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:357: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_elf_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:410: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:414: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:379: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:381: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_init_pcrel_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1798: undefined reference to `htab_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_free_pcrel_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1815: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_init_pcrel_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1798: undefined reference to `htab_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_resolve_pcrel_lo_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1905: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-riscv.o): in function `riscv_elf_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1473: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:379: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:381: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_record_pcrel_hi_reloc':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1866: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_elf_finish_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:3285: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_elf_get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:344: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:357: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_elf_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:410: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:414: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:379: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:381: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_init_pcrel_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1798: undefined reference to `htab_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_free_pcrel_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1815: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_init_pcrel_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1798: undefined reference to `htab_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_resolve_pcrel_lo_relocs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1905: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-riscv.o): in function `riscv_elf_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-riscv.c:1473: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-sparc.o): in function `_bfd_sparc_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1123: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1125: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-sparc.o): in function `elf_sparc_get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1086: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1099: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-sparc.o): in function `_bfd_sparc_elf_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1188: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1192: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-sparc.o): in function `_bfd_sparc_elf_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1123: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:1125: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-sparc.o): in function `_bfd_sparc_elf_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:2505: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-sparc.o): in function `_bfd_sparc_elf_finish_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-sparc.c:4775: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `map_removal_by_action':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5761: undefined reference to `splay_tree_foreach'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `text_action_add':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5609: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5616: undefined reference to `splay_tree_insert'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5599: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `action_first':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5559: undefined reference to `splay_tree_min'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `removed_by_actions':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5668: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `action_next':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5566: undefined reference to `splay_tree_successor'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `build_xlate_map':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:8487: undefined reference to `splay_tree_foreach'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `find_fill_action':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5478: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5478: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `text_action_add_literal':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5644: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5645: undefined reference to `splay_tree_insert'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `find_fill_action':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5478: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5478: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `init_xtensa_relax_info':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:6147: undefined reference to `splay_tree_new'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `find_insn_action':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5836: undefined reference to `splay_tree_lookup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `relax_section':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:9822: undefined reference to `splay_tree_foreach'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `action_first':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5559: undefined reference to `splay_tree_min'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-xtensa.o): in function `action_next':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-xtensa.c:5566: undefined reference to `splay_tree_successor'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-spu.o): in function `spu_elf_auto_overlay':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4334: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4334: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4334: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4334: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4334: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-spu.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4334: more undefined references to `filename_cmp' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-spu.o): in function `spu_elf_auto_overlay':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4692: undefined reference to `xexit'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4686: undefined reference to `xexit'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-spu.o): in function `sort_bfds':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-spu.c:4102: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: linux/bfd.o: in function `arch_bfdDemangle':
bfd.c:(.text+0x241): undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: bfd.c:(.text+0x29b): undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: bfd.c:(.text+0x2ed): undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: bfd.c:(.text+0x357): undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: bfd.c:(.text+0x3a9): undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: linux/bfd.o:bfd.c:(.text+0x3fc): more undefined references to `cplus_demangle' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(disassemble.o): in function `remove_whitespace_and_extra_commas':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/disassemble.c:793: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/disassemble.c:801: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(avr-dis.o): in function `print_insn_avr':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/avr-dis.c:330: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(epiphany-opc.o): in function `epiphany_cgen_init_opcode_table':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-opc.c:3998: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(riscv-dis.o): in function `parse_riscv_dis_options':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/riscv-dis.c:129: undefined reference to `xstrdup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(riscv-dis.o): in function `riscv_disassemble_insn':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/riscv-dis.c:453: undefined reference to `xcalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(s390-dis.o): in function `disassembler_options_s390':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/s390-dis.c:392: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/s390-dis.c:396: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/s390-dis.c:397: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-bitset.o): in function `cgen_bitset_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-bitset.c:44: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-bitset.o): in function `cgen_bitset_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-bitset.c:31: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(xtensa-dis.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/xtensa-dis.c:306: more undefined references to `xmalloc' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(epiphany-desc.o): in function `epiphany_cgen_cpu_close':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-desc.c:2263: undefined reference to `xregfree'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/epiphany-desc.c:2271: undefined reference to `xregfree'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-asm.o): in function `build_asm_hash_table':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-asm.c:135: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-asm.c:138: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libopcodes.a(cgen-asm.o): in function `cgen_parse_keyword':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/opcodes/../../opcodes/cgen-asm.c:220: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archures.o): in function `bfd_default_scan':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archures.c:1202: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(bfd.o): in function `_bfd_doprnt_scan':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:1164: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:1180: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:1217: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(bfd.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:1192: more undefined references to `_sch_istable' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(bfd.o): in function `bfd_demangle':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:2406: undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:2406: undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:2406: undefined reference to `cplus_demangle'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(bfd.o): in function `bfd_errmsg':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/bfd.c:809: undefined reference to `xstrerror'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(hash.o): in function `bfd_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/hash.c:426: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(hash.o): in function `bfd_hash_table_init_n':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/hash.c:385: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/hash.c:392: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(hash.o): in function `bfd_hash_insert':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/hash.c:536: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(hash.o): in function `bfd_hash_lookup':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/hash.c:486: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(hash.o): in function `bfd_hash_allocate':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/hash.c:623: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `find_separate_debug_file':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:1498: undefined reference to `lrealpath'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `_bfd_new_bfd':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:74: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:74: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:87: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `_bfd_free_cached_info':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:169: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:169: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `_bfd_delete_bfd':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `bfd_alloc':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:1032: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `bfd_create_gnu_debuglink_section':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:1706: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `bfd_fill_in_gnu_debuglink_section':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:1800: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `_bfd_delete_bfd':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:129: more undefined references to `objalloc_free' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(opncls.o): in function `bfd_release':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/opncls.c:1067: undefined reference to `objalloc_free_block'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(binary.o): in function `mangle_name':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/binary.c:139: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ihex.o): in function `ihex_bad_byte':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ihex.c:221: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ihex.o): in function `ihex_read_section':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ihex.c:574: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ihex.o): in function `ihex_object_p':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ihex.c:513: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ihex.o): in function `ihex_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ihex.c:168: undefined reference to `hex_init'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_bad_byte':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:251: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:186: undefined reference to `hex_init'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_read_section':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:742: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_scan':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:469: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:373: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:425: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:186: undefined reference to `hex_init'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_object_p':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:654: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(srec.o): in function `srec_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/srec.c:186: undefined reference to `hex_init'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(tekhex.o): in function `getvalue':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/tekhex.c:279: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(tekhex.o): in function `getsym':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/tekhex.c:304: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(tekhex.o): in function `first_phase':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/tekhex.c:379: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(tekhex.o): in function `tekhex_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/tekhex.c:213: undefined reference to `hex_init'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(tekhex.o): in function `pass_over':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/tekhex.c:540: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(tekhex.o): in function `tekhex_object_p':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/tekhex.c:614: undefined reference to `_hex_value'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(verilog.o): in function `verilog_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/verilog.c:342: undefined reference to `hex_init'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf.o): in function `_bfd_elf_is_local_label_name':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf.c:9127: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf-eh-frame.o): in function `cie_compute_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:261: undefined reference to `iterative_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:262: undefined reference to `iterative_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:263: undefined reference to `iterative_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:264: undefined reference to `iterative_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:265: undefined reference to `iterative_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf-eh-frame.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:266: more undefined references to `iterative_hash' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf-eh-frame.o): in function `find_merged_cie':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:1300: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:1296: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf-eh-frame.o): in function `_bfd_elf_discard_section_eh_frame_hdr':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf-eh-frame.c:1624: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(dwarf2.o): in function `hash_abbrev':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:986: undefined reference to `htab_hash_pointer'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(dwarf2.o): in function `read_abbrevs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:1039: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(dwarf2.o): in function `_bfd_dwarf2_find_symbol_bias':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4897: undefined reference to `xcalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4897: undefined reference to `htab_create_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4905: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4924: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4935: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(dwarf2.o): in function `_bfd_dwarf2_cleanup_debug_info':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:5290: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(dwarf2.o): in function `_bfd_dwarf2_slurp_debug_info':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4667: undefined reference to `htab_create_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4672: undefined reference to `htab_create_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(dwarf2.o): in function `hash_asymbol':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/dwarf2.c:4865: undefined reference to `htab_hash_string'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-i386.o): in function `elf_i386_output_arch_local_syms':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf32-i386.c:4129: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(cofflink.o): in function `coff_link_add_symbols':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/cofflink.c:551: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-aarch64.o): in function `elf32_aarch64_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2887: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2889: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-aarch64.o): in function `elf32_aarch64_get_local_sym_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2802: undefined reference to `htab_find_slot_with_hash'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2815: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-aarch64.o): in function `elf32_aarch64_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2930: undefined reference to `htab_try_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2934: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-aarch64.o): in function `elf32_aarch64_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2887: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:2889: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-aarch64.o): in function `elf32_aarch64_finish_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:9749: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf32-aarch64.o): in function `elf32_aarch64_size_dynamic_sections':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/elfnn-aarch64.c:8998: undefined reference to `htab_traverse'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ecofflink.o): in function `add_file_shuffle':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:408: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ecofflink.o): in function `add_memory_shuffle':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:441: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ecofflink.o): in function `bfd_ecoff_debug_init':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:510: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:510: undefined reference to `objalloc_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ecofflink.o): in function `bfd_ecoff_debug_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:536: undefined reference to `objalloc_free'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ecofflink.o): in function `bfd_ecoff_debug_accumulate':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:638: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:739: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:777: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:962: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:986: undefined reference to `_objalloc_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ecofflink.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ecofflink.c:1159: more undefined references to `_objalloc_alloc' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-hppa.o): in function `elf64_hppa_finalize_opd':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-hppa.c:2157: undefined reference to `concat'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elf64-hppa.o): in function `allocate_global_data_opd':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elf64-hppa.c:1093: undefined reference to `concat'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `xcoff_archive_info_hash':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:496: undefined reference to `htab_hash_pointer'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `_bfd_xcoff_bfd_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:583: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `xcoff_get_archive_info':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:521: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `xcoff_set_import_path':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:760: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:761: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:762: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `_bfd_xcoff_bfd_link_hash_table_create':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:611: undefined reference to `htab_create'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `_bfd_xcoff_bfd_link_hash_table_free':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:583: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xcofflink.o): in function `bfd_xcoff_split_import_path':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xcofflink.c:693: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(ppcboot.o): in function `mangle_name':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/ppcboot.c:263: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-riscv.o): in function `riscv_parsing_subset_version':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1436: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-riscv.o): in function `riscv_add_implicit_subset':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1334: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1335: undefined reference to `xstrdup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-riscv.o): in function `riscv_add_subset':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1305: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1310: undefined reference to `xstrdup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-riscv.o): in function `riscv_parse_subset':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1768: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-riscv.o): in function `riscv_parse_prefixed_ext':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1659: undefined reference to `xstrdup'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1663: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(elfxx-riscv.o): in function `riscv_arch_str':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1929: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/elfxx-riscv.c:1930: undefined reference to `xmalloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xtensa-isa.o): in function `xtensa_regfile_lookup':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xtensa-isa.c:1351: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(xtensa-isa.o): in function `xtensa_regfile_lookup_shortname':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/xtensa-isa.c:1381: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(mach-o.o): in function `bfd_mach_o_follow_dsym':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/mach-o.c:6082: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(pef.o): in function `bfd_pef_parse_traceback_table':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pef.c:187: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pef.c:187: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(pef.o): in function `bfd_pef_parse_function_stubs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pef.c:836: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pef.c:836: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pef.c:836: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(pef.o):/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/pef.c:836: more undefined references to `_sch_istable' follow
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(plugin.o): in function `build_plugin_list':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/plugin.c:510: undefined reference to `make_relative_prefix'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/plugin.c:533: undefined reference to `concat'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `adjust_relative_path':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1405: undefined reference to `getpwd'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1409: undefined reference to `lrealpath'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1412: undefined reference to `lrealpath'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1426: undefined reference to `filename_ncmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_look_for_bfd_in_cache':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:311: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_add_bfd_to_archive_cache':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:372: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:361: undefined reference to `htab_create_alloc'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_generic_read_ar_hdr_mag':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:538: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_append_relative_path':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:632: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_look_for_bfd_in_cache':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:311: undefined reference to `htab_find'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `find_nested_archive':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:406: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:416: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_construct_extended_name_table':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1576: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `normalize':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1366: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_construct_extended_name_table':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1622: undefined reference to `filename_ncmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1670: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1622: undefined reference to `filename_ncmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `normalize':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1366: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1366: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_bsd44_write_ar_hdr':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1785: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `normalize':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1366: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `bfd_bsd_truncate_arname':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2034: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `normalize':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:1366: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `bfd_gnu_truncate_arname':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2066: undefined reference to `lbasename'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_unlink_from_archive_parent':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2815: undefined reference to `htab_find_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2819: undefined reference to `htab_clear_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2819: undefined reference to `htab_clear_slot'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(archive.o): in function `_bfd_archive_close_and_cleanup':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2844: undefined reference to `htab_traverse_noresize'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/archive.c:2845: undefined reference to `htab_delete'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(cache.o): in function `bfd_open_file':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/cache.c:633: undefined reference to `unlink_if_ordinary'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(compress.o): in function `decompress_contents':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:51: undefined reference to `inflateInit_'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:58: undefined reference to `inflate'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:61: undefined reference to `inflateReset'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:63: undefined reference to `inflateEnd'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:63: undefined reference to `inflateEnd'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(compress.o): in function `bfd_is_section_compressed_with_header':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:456: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(compress.o): in function `bfd_compress_section_contents':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:126: undefined reference to `compressBound'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/compress.c:173: undefined reference to `compress'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(corefile.o): in function `generic_core_file_matches_executable_p':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/corefile.c:188: undefined reference to `filename_cmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(stabs.o): in function `_bfd_link_section_stabs':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/stabs.c:352: undefined reference to `_sch_istable'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(syms.o): in function `bfd_decode_symclass':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/syms.c:712: undefined reference to `_sch_toupper'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/gcc/x86_64-suse-linux/11/../../../../lib64/libbfd.a(syms.o): in function `_bfd_stab_section_find_nearest_line':
/home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/syms.c:1413: undefined reference to `filename_ncmp'
/usr/lib64/gcc/x86_64-suse-linux/11/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/binutils-2.37/build-dir/bfd/../../bfd/syms.c:1414: undefined reference to `filename_cmp'
collect2: error: ld returned 1 exit status
make: *** [Makefile:279: honggfuzz] Error 1
```

</details>

Given the name of the symbols, I figured `-liberty` and `-lz` was required, and it worked:


<details>
<summary>Make output with this patch</summary>

```
honggfuzz on  master
❯ make
cc -o honggfuzz cmdline.o display.o fuzz.o honggfuzz.o input.o mangle.o report.o sanitizers.o socketfuzzer.o subproc.o linux/arch.o linux/bfd.o linux/perf.o linux/pt.o linux/trace.o linux/unwind.o libhfcommon/libhfcommon.a -pthread -lm -L/usr/local/include -lunwind-ptrace -lunwind-generic -lunwind  -llzma -lopcodes -lbfd -liberty -lz -lrt -ldl -lm
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfuzz/fetch.o libhfuzz/fetch.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfuzz/instrument.o libhfuzz/instrument.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfuzz/linux.o libhfuzz/linux.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfuzz/memorycmp.o libhfuzz/memorycmp.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfuzz/performance.o libhfuzz/performance.c
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfuzz/persistent.o libhfuzz/persistent.c
ar rcs libhfuzz/libhfuzz.a libhfuzz/fetch.o libhfuzz/instrument.o libhfuzz/linux.o libhfuzz/memorycmp.o libhfuzz/performance.o libhfuzz/persistent.o
cc -c -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX -fPIC -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0   -o libhfnetdriver/netdriver.o libhfnetdriver/netdriver.c
ar rcs libhfnetdriver/libhfnetdriver.a libhfnetdriver/netdriver.o
cc -o hfuzz_cc/hfuzz-cc hfuzz_cc/hfuzz-cc.c libhfcommon/libhfcommon.a -pthread -lm -L/usr/local/include -lunwind-ptrace -lunwind-generic -lunwind  -llzma -lopcodes -lbfd -liberty -lz -lrt -ldl -lm -O3 -mtune=native -funroll-loops -std=c11 -I/usr/local/include -D_GNU_SOURCE -Wall -Wextra -Werror -Wno-format-truncation -Wno-override-init -I. -D_FILE_OFFSET_BITS=64 -finline-limit=4000 -D_HF_ARCH_LINUX  -D_HFUZZ_INC_PATH=/home/auroden/git/honggfuzz
cc -shared libhfuzz/fetch.o libhfuzz/instrument.o libhfuzz/linux.o libhfuzz/memorycmp.o libhfuzz/performance.o libhfuzz/persistent.o libhfcommon/files.o libhfcommon/log.o libhfcommon/ns.o libhfcommon/util.o -pthread -lm -L/usr/local/include -lunwind-ptrace -lunwind-generic -lunwind  -llzma -lopcodes -lbfd -liberty -lz -lrt -ldl -lm -o libhfuzz/libhfuzz.so
```

</details>

I'm compiling on openSUSE Tumbleweed, I don't know if it's related?
If the patch is not appropriate and there is a specific configuration for that, feel free to close!