### PR TITLE
using __builtin_memcpy_inline from LLVM in few places.

### DIFF
--- a/libhfcommon/util.c
+++ b/libhfcommon/util.c
@@ -397,13 +397,13 @@ void util_sleepForMSec(uint64_t msec) {
 
 uint64_t util_getUINT32(const uint8_t* buf) {
     uint32_t r;
-    memcpy(&r, buf, sizeof(r));
+    util_memcpyInline(&r, buf, sizeof(r));
     return (uint64_t)r;
 }
 
 uint64_t util_getUINT64(const uint8_t* buf) {
     uint64_t r;
-    memcpy(&r, buf, sizeof(r));
+    util_memcpyInline(&r, buf, sizeof(r));
     return r;
 }
 

--- a/libhfcommon/util.h
+++ b/libhfcommon/util.h
@@ -110,6 +110,20 @@ static void __attribute__((unused)) __clang_cleanup_func(void (^*dfunc)(void)) {
 #define LIKELY(cond)   __builtin_expect(!!(cond), true)
 #define UNLIKELY(cond) __builtin_expect(!!(cond), false)
 
+#if !defined(__has_builtin)
+#define __has_builtin(b) 0
+#endif
+
+#if !__has_builtin(__builtin_memcpy_inline)
+#define util_memcpyInline(x, y, s)										\
+	do {													\
+		_Static_assert(__builtin_choose_expr(__builtin_constant_p(s), 1, 0), "len must be a constant");	\
+		__builtin_memcpy(x, y, s);									\
+	} while (0)
+#else
+#define util_memcpyInline(x, y, s) __builtin_memcpy_inline(x, y, s)
+#endif
+
 /* Atomics */
 #define ATOMIC_GET(x)     __atomic_load_n(&(x), __ATOMIC_RELAXED)
 #define ATOMIC_SET(x, y)  __atomic_store_n(&(x), y, __ATOMIC_RELAXED)

--- a/mangle.c
+++ b/mangle.c
@@ -569,7 +569,7 @@ static inline void mangle_AddSubWithRange(
         }
         case 2: {
             int16_t val;
-            memcpy(&val, &run->dynfile->data[off], sizeof(val));
+            util_memcpyInline(&val, &run->dynfile->data[off], sizeof(val));
             if (util_rnd64() & 0x1) {
                 val += delta;
             } else {
@@ -583,7 +583,7 @@ static inline void mangle_AddSubWithRange(
         }
         case 4: {
             int32_t val;
-            memcpy(&val, &run->dynfile->data[off], sizeof(val));
+            util_memcpyInline(&val, &run->dynfile->data[off], sizeof(val));
             if (util_rnd64() & 0x1) {
                 val += delta;
             } else {
@@ -597,7 +597,7 @@ static inline void mangle_AddSubWithRange(
         }
         case 8: {
             int64_t val;
-            memcpy(&val, &run->dynfile->data[off], sizeof(val));
+            util_memcpyInline(&val, &run->dynfile->data[off], sizeof(val));
             if (util_rnd64() & 0x1) {
                 val += delta;
             } else {


### PR DESCRIPTION
Differences with __builtin_memcpy are it does not generate
extra calls and it can work only with compile time sizes.