### PR TITLE
Follow-up on #466

### DIFF
--- a/input.c
+++ b/input.c
@@ -658,7 +658,7 @@ bool input_prepareStaticFile(run_t* run, bool rewind, bool needs_mangle) {
     }
 
     input_setSize(run, fileSz);
-    memset(run->dynfile->cov, '\0', sizeof(run->dynfile->cov));
+    util_memsetInline(run->dynfile->cov, '\0', sizeof(run->dynfile->cov));
     run->dynfile->idx  = 0;
     run->dynfile->src  = NULL;
     run->dynfile->refs = 0;

--- a/libhfcommon/ns.c
+++ b/libhfcommon/ns.c
@@ -26,6 +26,7 @@
 #include "libhfcommon/common.h"
 #include "libhfcommon/files.h"
 #include "libhfcommon/log.h"
+#include "libhfcommon/util.h"
 
 #if defined(_HF_ARCH_LINUX)
 
@@ -104,7 +105,7 @@ bool nsIfaceUp(const char* ifacename) {
     }
 
     struct ifreq ifr;
-    memset(&ifr, '\0', sizeof(ifr));
+    util_memsetInline(&ifr, '\0', sizeof(ifr));
     snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", ifacename);
 
     if (ioctl(sock, SIOCGIFFLAGS, &ifr) == -1) {

--- a/libhfcommon/util.h
+++ b/libhfcommon/util.h
@@ -124,6 +124,16 @@ static void __attribute__((unused)) __clang_cleanup_func(void (^*dfunc)(void)) {
 #define util_memcpyInline(x, y, s) __builtin_memcpy_inline(x, y, s)
 #endif
 
+#if !__has_builtin(__builtin_memset_inline)
+#define util_memsetInline(x, y, s)										\
+	do {													\
+		_Static_assert(__builtin_choose_expr(__builtin_constant_p(s), 1, 0), "len must be a constant");	\
+		__builtin_memset(x, y, s);									\
+	} while (0)
+#else
+#define util_memsetInline(x, y, s) __builtin_memset_inline(x, y, s)
+#endif
+
 /* Atomics */
 #define ATOMIC_GET(x)     __atomic_load_n(&(x), __ATOMIC_RELAXED)
 #define ATOMIC_SET(x, y)  __atomic_store_n(&(x), y, __ATOMIC_RELAXED)


### PR DESCRIPTION
Using __builtin_memset_inline from LLVM in few places.
__builtin_memset_inline being more recent, needs to be checked
separetely.