### PR TITLE
fuzz: fix memory leak

### DIFF
--- a/fuzz.c
+++ b/fuzz.c
@@ -497,6 +497,9 @@ static void* fuzz_threadNew(void* arg) {
         .persistentSock = -1,
         .tmOutSignaled  = false,
     };
+    defer {
+        free(run.dynfile);
+    }
 
     /* Do not try to handle input files with socketfuzzer */
     char mapname[32];


### PR DESCRIPTION
This makes leak sanitizers happier.
```
=================================================================
==12==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 50400 byte(s) in 12 object(s) allocated from:
    #0 0x55e9a4e82f0e in __interceptor_malloc (/home/robin/.cache/bazel/_bazel_robin/6dd7754dffee103a3dd07431f0d00ad8/execroot/__main__/bazel-out/k8-fastbuild/bin/external/honggfuzz/honggfuzz+0xa4f0e) (BuildId: d5de1d58dbc10971f045fc68385f5ef56edea20d)
    #1 0x55e9a4ed5e84 in util_Malloc /proc/self/cwd/external/honggfuzz/libhfcommon/util.c:181:15
    #2 0x55e9a4ed5ee4 in util_Calloc /proc/self/cwd/external/honggfuzz/libhfcommon/util.c:189:15
    #3 0x55e9a4ec1a07 in fuzz_threadNew /proc/self/cwd/external/honggfuzz/fuzz.c:495:39
    #4 0x7f91fc2d8b42 in start_thread nptl/./nptl/pthread_create.c:442:8

Objects leaked above:
0x621000021d00 (4200 bytes)
0x621000032100 (4200 bytes)
0x621000042500 (4200 bytes)
0x621000048900 (4200 bytes)
0x621000052900 (4200 bytes)
0x621000058d00 (4200 bytes)
0x621000061900 (4200 bytes)
0x621000067d00 (4200 bytes)
0x621000071d00 (4200 bytes)
0x621000078100 (4200 bytes)
0x621000082100 (4200 bytes)
0x621000092500 (4200 bytes)

SUMMARY: AddressSanitizer: 50400 byte(s) leaked in 12 allocation(s).
```

Not sure about commit message format, but I tried to copy what you're doing. :P