### PR TITLE
Support exit_on_time option: issue #399

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -500,6 +500,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "pprocess_cmd", required_argument, NULL, 0x111 }, "External command postprocessing files produced by internal mutators" },
         { { "ffmutate_cmd", required_argument, NULL, 0x110 }, "External command mutating files which have effective coverage feedback" },
         { { "run_time", required_argument, NULL, 0x109 }, "Number of seconds this fuzzing session will last (default: 0 [no limit])" },
+        { { "exit_on_time", required_argument, NULL, 0x10A }, "Stop fuzzing session if no new coverage was found for this number of seconds (default: 0 [no limit])" },
         { { "iterations", required_argument, NULL, 'N' }, "Number of fuzzing iterations (default: 0 [no limit])" },
         { { "rlimit_as", required_argument, NULL, 0x100 }, "Per process RLIMIT_AS in MiB (default: 0 [default limit])" },
         { { "rlimit_rss", required_argument, NULL, 0x101 }, "Per process RLIMIT_RSS in MiB (default: 0 [default limit]). It will also set *SAN's soft_rss_limit_mb" },
@@ -688,6 +689,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                     hfuzz->timing.runEndTime = time(NULL) + p;
                 }
             } break;
+            case 0x10A:
+                hfuzz->timing.exitOnTime = atol(optarg);
+                break;
             case 'N':
                 hfuzz->mutate.mutationsMax = atol(optarg);
                 break;

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -282,6 +282,11 @@ static uint8_t mainThreadLoop(honggfuzz_t* hfuzz) {
             LOG_I("Maximum run time reached, terminating");
             break;
         }
+        if (hfuzz->timing.exitOnTime > 0 &&
+                time(NULL) - ATOMIC_GET(hfuzz->timing.lastCovUpdate) > hfuzz->timing.exitOnTime) {
+            LOG_I("No new coverage was found for the last %ld seconds, terminating", hfuzz->timing.exitOnTime);
+            break;
+        }
         pingThreads(hfuzz);
         pause();
     }

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -243,6 +243,7 @@ typedef struct {
         time_t  runEndTime;
         time_t  tmOut;
         time_t  lastCovUpdate;
+        time_t  exitOnTime;
         int64_t timeOfLongestUnitUSecs;
         bool    tmoutVTALRM;
     } timing;


### PR DESCRIPTION
Hi! This PR implements exit-on-time option (alike in afl++) which allows to stop fuzzing session when there is no new coverage discovered for a certain amount of time. This functionality is used for automatic fuzz testing organizing.
There is also an issue #399 requesting this feature.