### PR TITLE
Pastis patch for Honggfuzz

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -528,6 +528,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "const_feedback", required_argument, NULL, 0x112 }, "Use constant integer/string values from fuzzed programs to mangle input files via a dynamic dictionary (default: true)" },
         { { "pin_thread_cpu", required_argument, NULL, 0x114 }, "Pin a single execution thread to this many consecutive CPUs (default: 0 = no CPU pinning)" },
         { { "dynamic_input", required_argument, NULL, 0x115 }, "Path to a directory containing the dynamic file corpus" },
+        { { "statsfile", required_argument, NULL, 0x116 }, "Stats file" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blocklist filter file (one entry per line)" },
@@ -812,6 +813,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
 #endif
             case 0x115:
                 hfuzz->io.dynamicInputDir = optarg;
+                break;
+            case 0x116:
+                hfuzz->io.statsFileName = optarg;
                 break;
             default:
                 cmdlineHelp(argv[0], custom_opts);

--- a/cmdline.c
+++ b/cmdline.c
@@ -527,6 +527,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "export_feedback", no_argument, NULL, 0x10E }, "Export the coverage feedback structure as ./hfuzz-feedback" },
         { { "const_feedback", required_argument, NULL, 0x112 }, "Use constant integer/string values from fuzzed programs to mangle input files via a dynamic dictionary (default: true)" },
         { { "pin_thread_cpu", required_argument, NULL, 0x114 }, "Pin a single execution thread to this many consecutive CPUs (default: 0 = no CPU pinning)" },
+        { { "dynamic_input", required_argument, NULL, 0x115 }, "Path to a directory containing the dynamic file corpus" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blocklist filter file (one entry per line)" },
@@ -809,6 +810,9 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 hfuzz->arch_linux.disableRandomization = false;
                 break;
 #endif
+            case 0x115:
+                hfuzz->io.dynamicInputDir = optarg;
+                break;
             default:
                 cmdlineHelp(argv[0], custom_opts);
                 return false;

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -23,12 +23,14 @@
  */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -414,6 +416,16 @@ int main(int argc, char** argv) {
                 sizeof(cmpfeedback_t), hfuzz.io.workDir);
         }
     }
+    /* Stats file. */
+    if (hfuzz.io.statsFileName) {
+        hfuzz.io.statsFileFd = TEMP_FAILURE_RETRY(open(hfuzz.io.statsFileName, O_CREAT | O_RDWR | O_TRUNC, 0640));
+
+        if (hfuzz.io.statsFileFd == -1) {
+            PLOG_F("Couldn't open statsfile open('%s')", hfuzz.io.statsFileName);
+        } else {
+            dprintf(hfuzz.io.statsFileFd, "# unix_time, last_cov_update, total_exec, exec_per_sec, crashes, unique_crashes, hangs, edge_cov, block_cov\n");
+        }
+    }
 
     setupRLimits();
     setupSignalsPreThreads();
@@ -447,6 +459,10 @@ int main(int argc, char** argv) {
 #endif
     if (hfuzz.socketFuzzer.enabled) {
         cleanupSocketFuzzer();
+    }
+    /* Stats file. */
+    if (hfuzz.io.statsFileName) {
+        close(hfuzz.io.statsFileFd);
     }
 
     printSummary(&hfuzz);

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -264,6 +264,11 @@ static uint8_t mainThreadLoop(honggfuzz_t* hfuzz) {
     setupMainThreadTimer();
 
     for (;;) {
+        if (hfuzz->io.dynamicInputDir) {
+            LOG_D("Loading files from the dynamic input queue...");
+            input_enqueueDynamicInputs(hfuzz);
+        }
+
         if (hfuzz->display.useScreen) {
             if (ATOMIC_XCHG(clearWin, false)) {
                 display_clear();

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -218,6 +218,8 @@ typedef struct {
         TAILQ_HEAD(dyns_t, _dynfile_t) dynfileq;
         bool exportFeedback;
         const char* dynamicInputDir;
+        const char* statsFileName;
+        int statsFileFd;
     } io;
     struct {
         int                argc;

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -217,6 +217,7 @@ typedef struct {
         dynfile_t*  dynfileq2Current;
         TAILQ_HEAD(dyns_t, _dynfile_t) dynfileq;
         bool exportFeedback;
+        const char* dynamicInputDir;
     } io;
     struct {
         int                argc;

--- a/input.c
+++ b/input.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/queue.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -572,6 +573,125 @@ bool input_prepareDynamicInput(run_t* run, bool needs_mangle) {
     }
 
     return true;
+}
+
+bool input_dynamicQueueGetNext(char fname[PATH_MAX], DIR* dynamicDirPtr, char *dynamicWorkDir) {
+    static pthread_mutex_t input_mutex = PTHREAD_MUTEX_INITIALIZER;
+    MX_SCOPED_LOCK(&input_mutex);
+
+    for (;;) {
+        errno = 0;
+        struct dirent* entry = readdir(dynamicDirPtr);
+        if (entry == NULL && errno == EINTR) {
+            continue;
+        }
+        if (entry == NULL && errno != 0) {
+            PLOG_W("readdir_r('%s')", dynamicWorkDir);
+            return false;
+        }
+        if (entry == NULL) {
+            return false;
+        }
+        char path[PATH_MAX];
+        snprintf(path, PATH_MAX, "%s/%s", dynamicWorkDir, entry->d_name);
+        struct stat st;
+        if (stat(path, &st) == -1) {
+            LOG_W("Couldn't stat() the '%s' file", path);
+            continue;
+        }
+        if (!S_ISREG(st.st_mode)) {
+            LOG_D("'%s' is not a regular file, skipping", path);
+            continue;
+        }
+
+        snprintf(fname, PATH_MAX, "%s/%s", dynamicWorkDir, entry->d_name);
+        return true;
+    }
+}
+
+void input_enqueueDynamicInputs(honggfuzz_t* hfuzz) {
+    char dynamicWorkDir[PATH_MAX];
+
+    snprintf(dynamicWorkDir, sizeof(dynamicWorkDir), "%s", hfuzz->io.dynamicInputDir);
+
+    int dynamicDirFd = TEMP_FAILURE_RETRY(open(dynamicWorkDir, O_DIRECTORY | O_RDONLY | O_CLOEXEC));
+    if (dynamicDirFd == -1) {
+        PLOG_W("open('%s', O_DIRECTORY|O_RDONLY|O_CLOEXEC)", dynamicWorkDir);
+        return;
+    }
+
+    DIR* dynamicDirPtr;
+    if ((dynamicDirPtr = fdopendir(dynamicDirFd)) == NULL) {
+        PLOG_W("fdopendir(dir='%s', fd=%d)", dynamicWorkDir, dynamicDirFd);
+        close(dynamicDirFd);
+        return;
+    }
+
+    char dynamicInputFileName[PATH_MAX];
+    for (;;) {
+        if (!input_dynamicQueueGetNext(dynamicInputFileName, dynamicDirPtr, dynamicWorkDir)) {
+            break;
+        }
+
+        int dynamicFileFd;
+        if ((dynamicFileFd = open(dynamicInputFileName, O_RDWR)) == -1) {
+            PLOG_E("Error opening dynamic input file: %s", dynamicInputFileName);
+            continue;
+        }
+
+        /* Get file status. */
+        struct stat dynamicFileStat;
+        size_t dynamicFileSz;
+
+        if (fstat(dynamicFileFd, &dynamicFileStat) == -1) {
+            PLOG_E("Error getting file status: %s", dynamicInputFileName);
+            close(dynamicFileFd);
+            continue;
+        }
+
+        dynamicFileSz = dynamicFileStat.st_size;
+
+        uint8_t* dynamicFile = (uint8_t *) mmap(NULL, dynamicFileSz, PROT_READ | PROT_WRITE, MAP_SHARED, dynamicFileFd, 0);
+
+        if (dynamicFile == MAP_FAILED) {
+            PLOG_E("Error mapping dynamic input file: %s", dynamicInputFileName);
+            close(dynamicFileFd);
+            continue;
+        }
+
+        LOG_I("Loading dynamic input file: %s (%lu)", dynamicInputFileName, dynamicFileSz);
+
+        run_t tmp_run;
+        tmp_run.global = hfuzz;
+        dynfile_t tmp_dynfile = {
+            .size          = dynamicFileSz,
+            .cov           = {0xff, 0xff, 0xff, 0xff},
+            .idx           = 0,
+            .fd            = -1,
+            .timeExecUSecs = 1,
+            .path          = "",
+            .data          = dynamicFile,
+        };
+        tmp_run.timeStartedUSecs = util_timeNowUSecs() -1;
+        memcpy(tmp_dynfile.path, dynamicInputFileName, PATH_MAX);
+        tmp_run.dynfile = &tmp_dynfile;
+        input_addDynamicInput(&tmp_run);
+        //input_addDynamicInput(hfuzz, dynamicFile, dynamicFileSz, (uint64_t[4]){0xff, 0xff, 0xff, 0xff}, dynamicInputFileName);
+
+        /* Unmap input file. */
+        if (munmap((void *) dynamicFile, dynamicFileSz) == -1) {
+            PLOG_E("Error unmapping input file!");
+        }
+
+        /* Close input file. */
+        if (close(dynamicFileFd) == -1) {
+            PLOG_E("Error closing input file!");
+        }
+
+        /* Remove enqueued file from the directory. */
+        unlink(dynamicInputFileName);
+    }
+    closedir(dynamicDirPtr);
 }
 
 const uint8_t* input_getRandomInputAsBuf(run_t* run, size_t* len) {

--- a/input.h
+++ b/input.h
@@ -49,5 +49,7 @@ extern bool           input_removeStaticFile(const char* dir, const char* name);
 extern bool           input_prepareExternalFile(run_t* run);
 extern bool           input_postProcessFile(run_t* run, const char* cmd);
 extern bool           input_prepareDynamicFileForMinimization(run_t* run);
+extern bool           input_dynamicQueueGetNext(char fname[PATH_MAX], DIR* dynamicDirPtr, char *dynamicWorkDir);
+extern void           input_enqueueDynamicInputs(honggfuzz_t* hfuzz);
 
 #endif /* ifndef _HF_INPUT_H_ */


### PR DESCRIPTION
This patch adds two features:

* dynamic input directory (e.g. a libafl/AFL/libfuzzer corpus directory) from which periodically new inputs are read from (`--dynamic-input <DIR>`)
* a statistic file that prints some data that can be parsed by scripts (`--statsfile <FILE>`)

This PR is related to PR #498 .