### PR TITLE
add --version cmdline parameter

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -486,6 +486,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "stdin_input", no_argument, NULL, 's' }, "Provide fuzzing input on STDIN, instead of " _HF_FILE_PLACEHOLDER },
         { { "mutations_per_run", required_argument, NULL, 'r' }, "Maximal number of mutations per one run (default: 6)" },
         { { "logfile", required_argument, NULL, 'l' }, "Log file" },
+        { { "version", no_argument, NULL, '!' }, "Just how the version and exit" },
         { { "verbose", no_argument, NULL, 'v' }, "Disable ANSI console; use simple log output" },
         { { "verifier", no_argument, NULL, 'V' }, "Enable crashes verifier" },
         { { "debug", no_argument, NULL, 'd' }, "Show debug messages (level >= 4)" },
@@ -570,12 +571,15 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
     int           opt_index = 0;
     for (;;) {
         int c = getopt_long(
-            argc, argv, "-?hQvVsuUPxf:i:o:dqe:W:r:c:F:t:R:n:N:l:p:g:E:w:B:zMTS", opts, &opt_index);
+            argc, argv, "-?!hQvVsuUPxf:i:o:dqe:W:r:c:F:t:R:n:N:l:p:g:E:w:B:zMTS", opts, &opt_index);
         if (c < 0) {
             break;
         }
 
         switch (c) {
+            case '!':
+                LOG_HELP(PROG_NAME " " PROG_VERSION);
+                exit(0);
             case 'h':
                 cmdlineUsage(argv[0], custom_opts);
                 break;


### PR DESCRIPTION
There is no easy way to identify which honggfuzz version is installed as apparently the version is only displayed once the fuzzing UI is up.
So I added a --version command that exists to display the version.
