### PR TITLE
Fix log message not updating total counters

### DIFF
--- a/fuzz.c
+++ b/fuzz.c
@@ -236,7 +236,8 @@ static void fuzz_perfFeedback(run_t* run) {
             run->dynfile->size, util_timeNowUSecs() - run->timeStartedUSecs,
             run->hwCnts.cpuInstrCnt, run->hwCnts.cpuBranchCnt, run->hwCnts.newBBCnt, softNewEdge,
             softNewPC, softNewCmp, run->hwCnts.cpuInstrCnt, run->hwCnts.cpuBranchCnt,
-            run->hwCnts.bbCnt, softCurEdge, softCurPC, softCurCmp);
+            run->global->feedback.hwCnts.bbCnt, run->global->feedback.hwCnts.softCntEdge,
+            run->global->feedback.hwCnts.softCntPc, run->global->feedback.hwCnts.softCntCmp);
 
         if (run->global->io.statsFileName) {
             const time_t curr_sec      = time(NULL);


### PR DESCRIPTION
When fuzzing without tty (or with —verbose), and an increase in corpus happens totals are always zero. 

For example:
(…) New:1/2/3/4/5/6 Cur:0/0/0/0/0/0

Fixed:
(…) New:1/2/3/4/5/6 Cur:7/8/9/10/11/12

