### PR TITLE
keep original files after using postprocessor and allow postprocessor in dry mode

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -387,6 +387,8 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .only_printable    = false,
                 .minimize          = false,
                 .switchingToFDM    = false,
+		.pp_keepOriginal   = false,
+		.pp_dry		   = false,
             },
         .sanitizer =
             {
@@ -503,6 +505,8 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "stackhash_bl", required_argument, NULL, 'B' }, "Stackhashes blocklist file (one entry per line)" },
         { { "mutate_cmd", required_argument, NULL, 'c' }, "External command producing fuzz files (instead of internal mutators)" },
         { { "pprocess_cmd", required_argument, NULL, 0x111 }, "External command postprocessing files produced by internal mutators" },
+        { { "pp_keep", required_argument, NULL, 0x117 }, "Keep original file after running postprocessor" },
+        { { "pp_dry", required_argument, NULL, 0x118 }, "Run postprocessor in dry mode, too" },
         { { "ffmutate_cmd", required_argument, NULL, 0x110 }, "External command mutating files which have effective coverage feedback" },
         { { "run_time", required_argument, NULL, 0x109 }, "Number of seconds this fuzzing session will last (default: 0 [no limit])" },
         { { "exit_on_time", required_argument, NULL, 0x10A }, "Stop fuzzing session if no new coverage was found for this number of seconds (default: 0 [no limit])" },
@@ -666,6 +670,12 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
             break;
         case 0x112:
             hfuzz->feedback.cmpFeedback = cmdlineParseTrueFalse(opts[opt_index].name, optarg);
+            break;
+        case 0x117:
+            hfuzz->cfg.pp_keepOriginal = cmdlineParseTrueFalse(opts[opt_index].name, optarg);
+            break;
+        case 0x118:
+            hfuzz->cfg.pp_dry = cmdlineParseTrueFalse(opts[opt_index].name, optarg);
             break;
         case 'z':
             hfuzz->feedback.dynFileMethod |= _HF_DYNFILE_SOFT;

--- a/fuzz.c
+++ b/fuzz.c
@@ -358,7 +358,7 @@ static bool fuzz_fetchInput(run_t* run) {
         fuzzState_t st = fuzz_getState(run->global);
         if (st == _HF_STATE_DYNAMIC_DRY_RUN) {
             run->mutationsPerRun = 0U;
-            if (input_prepareStaticFile(run, /* rewind= */ false, true)) {
+            if (input_prepareStaticFile(run, /* rewind= */ false, true, run->global->cfg.pp_dry)) {
                 return true;
             }
             fuzz_setDynamicMainState(run);
@@ -395,24 +395,24 @@ static bool fuzz_fetchInput(run_t* run) {
                 return false;
             }
         } else if (run->global->exe.feedbackMutateCommand) {
-            if (!input_prepareStaticFile(run, true, false)) {
+            if (!input_prepareStaticFile(run, true, false, false /*CHECK?*/)) {
                 LOG_E("input_prepareStaticFile() failed");
                 return false;
             }
-        } else if (!input_prepareStaticFile(run, true /* rewind */, true)) {
+        } else if (!input_prepareStaticFile(run, true /* rewind */, true, false)) {
             LOG_E("input_prepareStaticFile() failed");
             return false;
         }
     }
 
     if (run->global->exe.postExternalCommand &&
-        !input_postProcessFile(run, run->global->exe.postExternalCommand)) {
+        !input_postProcessFile(run, run->global->exe.postExternalCommand, run->global->cfg.pp_keepOriginal)) {
         LOG_E("input_postProcessFile('%s') failed", run->global->exe.postExternalCommand);
         return false;
     }
 
     if (run->global->exe.feedbackMutateCommand &&
-        !input_postProcessFile(run, run->global->exe.feedbackMutateCommand)) {
+        !input_postProcessFile(run, run->global->exe.feedbackMutateCommand, false)) {
         LOG_E("input_postProcessFile('%s') failed", run->global->exe.feedbackMutateCommand);
         return false;
     }

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -155,6 +155,8 @@ struct _dynfile_t {
     uint32_t           refs;
     fuzzState_t        phase;
     uint8_t*           data;
+    bool	       keepOriginal;
+    uint8_t*           originalData;
                        TAILQ_ENTRY(_dynfile_t) pointers;
 };
 
@@ -275,6 +277,8 @@ typedef struct {
         bool        only_printable;
         bool        minimize;
         bool        switchingToFDM;
+	bool        pp_keepOriginal;
+	bool	    pp_dry;
     } cfg;
     struct {
         bool enable;

--- a/input.h
+++ b/input.h
@@ -44,10 +44,10 @@ extern bool           input_inDynamicCorpus(run_t* run, const char* fname);
 extern void           input_renumerateInputs(honggfuzz_t* hfuzz);
 extern bool           input_prepareDynamicInput(run_t* run, bool needs_mangle);
 extern const uint8_t* input_getRandomInputAsBuf(run_t* run, size_t* len);
-extern bool           input_prepareStaticFile(run_t* run, bool rewind, bool needs_mangle);
+extern bool           input_prepareStaticFile(run_t* run, bool rewind, bool needs_mangle, bool needs_postprocess);
 extern bool           input_removeStaticFile(const char* dir, const char* name);
 extern bool           input_prepareExternalFile(run_t* run);
-extern bool           input_postProcessFile(run_t* run, const char* cmd);
+extern bool           input_postProcessFile(run_t* run, const char* cmd, bool keepOriginal);
 extern bool           input_prepareDynamicFileForMinimization(run_t* run);
 extern bool           input_dynamicQueueGetNext(
               char fname[PATH_MAX], DIR* dynamicDirPtr, char* dynamicWorkDir);

--- a/report.c
+++ b/report.c
@@ -98,6 +98,7 @@ void report_saveReport(run_t* run) {
         "FUZZER ARGS:\n"
         " mutationsPerRun : %u\n"
         " externalCmd     : %s\n"
+        " postProcessor   : %s\n"
         " fuzzStdin       : %s\n"
         " timeout         : %ld (sec)\n"
 #if defined(_HF_ARCH_LINUX) || defined(_HF_ARCH_NETBSD)
@@ -109,6 +110,7 @@ void report_saveReport(run_t* run) {
         " wordlistFile    : %s\n",
         localtmstr, run->global->mutate.mutationsPerRun,
         run->global->exe.externalCommand == NULL ? "NULL" : run->global->exe.externalCommand,
+        run->global->exe.postExternalCommand == NULL ? "NULL" : run->global->exe.postExternalCommand,
         run->global->exe.fuzzStdin ? "TRUE" : "FALSE", (long)run->global->timing.tmOut,
 #if defined(_HF_ARCH_LINUX)
         run->global->arch_linux.ignoreAddr,


### PR DESCRIPTION
should be useful for fuzzing input in container or compressed formats so input dir can keep original files and fuzzer produces correct format for fuzzed program