### PR TITLE
Support latest MacOS versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,8 @@ LNETDRIVER_OBJS := $(LNETDRIVER_SRCS:.c=.o)
 LNETDRIVER_ARCH := libhfnetdriver/libhfnetdriver.a
 
 # Respect external user defines
-CFLAGS += $(COMMON_CFLAGS) $(ARCH_CFLAGS) -D_HF_ARCH_${ARCH}
+REALOS_UPPER = $(shell echo $(REALOS) | tr '[:lower:]' '[:upper:]')
+CFLAGS += $(COMMON_CFLAGS) $(ARCH_CFLAGS) -D_HF_ARCH_${ARCH} -D_HF_ARCH_${REALOS_UPPER}
 LDFLAGS += $(COMMON_LDFLAGS) $(ARCH_LDFLAGS)
 
 ifdef DEBUG

--- a/cmdline.c
+++ b/cmdline.c
@@ -519,7 +519,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "save_all", no_argument, NULL, 'u' }, "Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames" },
         { { "save_smaller", no_argument, NULL, 'U' }, "Save smaller test-cases, renaming first filename with .orig suffix" },
         { { "tmout_sigvtalrm", no_argument, NULL, 'T' }, "Treat time-outs as crashes - use SIGVTALRM to kill timeouting processes (default: use SIGKILL)" },
-        { { "sanitizers", no_argument, NULL, 'S' }, "** DEPRECATED ** Enable sanitizers settings (default: false)" },
+        { { "sanitizers", no_argument, NULL, 'S' }, "Enable sanitizers settings (default: false)" },
         { { "sanitizers_del_report", required_argument, NULL, 0x10F }, "Delete sanitizer report after use (default: false)" },
         { { "monitor_sigabrt", required_argument, NULL, 0x105 }, "** DEPRECATED ** SIGABRT is always monitored" },
         { { "no_fb_timeout", required_argument, NULL, 0x106 }, "Skip feedback if the process has timeouted (default: false)" },

--- a/fuzz.c
+++ b/fuzz.c
@@ -260,7 +260,7 @@ static void fuzz_perfFeedback(run_t* run) {
 
             dprintf(run->global->io.statsFileFd,
                 "%lu, %lu, %lu, %lu, "
-                "%" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n",
+                "%zu, %zu, %zu, %" PRIu64 ", %" PRIu64 "\n",
                 curr_sec,                                 /* unix_time */
                 run->global->timing.lastCovUpdate,        /* last_cov_update */
                 curr_exec_cnt,                            /* total_exec */

--- a/posix/arch.c
+++ b/posix/arch.c
@@ -161,6 +161,8 @@ static void arch_analyzeSignal(run_t* run, pid_t pid, int status) {
             localtmstr, (int)pid, run->global->io.fileExtn);
     }
 
+    ATOMIC_POST_INC(run->global->cnts.crashesCnt);
+
     if (files_exists(run->crashFileName)) {
         LOG_I("Crash (dup): '%s' already exists, skipping", run->crashFileName);
         /* Clear filename so that verifier can understand we hit a duplicate */
@@ -170,7 +172,6 @@ static void arch_analyzeSignal(run_t* run, pid_t pid, int status) {
 
     LOG_I("Ok, that's interesting, saving input '%s'", run->crashFileName);
 
-    ATOMIC_POST_INC(run->global->cnts.crashesCnt);
     ATOMIC_POST_INC(run->global->cnts.uniqueCrashesCnt);
     /* If unique crash found, reset dynFile counter */
     ATOMIC_CLEAR(run->global->cfg.dynFileIterExpire);


### PR DESCRIPTION
Honggfuzz currently only supports MacOS until version 13 and only the X86-64 architecture. The reason is the reliance on `crashwrangle` for crash analysis, which is unavailable for the new ARM-based chips and seems to be discontinued. This PR adds support for all MacOS versions using the POSIX route. More specifically, the PR:
- enables building honggfuzz on MacOS with `OS=POSIX make all`: The Makefile is adjusted to include a preprocessor define for the original build system. For example, this is necessary to enable `hfuzz-cc` to ignore certain linker flags that are not compatible with the MacOS X linker.
- disables ASLR in the child process on MacOS: This is necessary for correct error deduplication through consistent stack hashes.
- undeprecates the `--sanitizers` flag: This flag is then needed for the sanitizer to properly handle signals such as `SIGSEGV` and dump a proper sanitizer log that can be used to compute stack hashes.

This PR fixes #519 and #477 