### PR TITLE
Include corpus queue size in stats file

### DIFF
--- a/fuzz.c
+++ b/fuzz.c
@@ -260,7 +260,7 @@ static void fuzz_perfFeedback(run_t* run) {
 
             dprintf(run->global->io.statsFileFd,
                 "%lu, %lu, %lu, %lu, "
-                "%" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n",
+                "%" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n",
                 curr_sec,                                 /* unix_time */
                 run->global->timing.lastCovUpdate,        /* last_cov_update */
                 curr_exec_cnt,                            /* total_exec */
@@ -269,7 +269,8 @@ static void fuzz_perfFeedback(run_t* run) {
                 run->global->cnts.uniqueCrashesCnt,       /* unique_crashes */
                 run->global->cnts.timeoutedCnt,           /* hangs */
                 run->global->feedback.hwCnts.softCntEdge, /* edge_cov */
-                run->global->feedback.hwCnts.softCntPc    /* block_cov */
+                run->global->feedback.hwCnts.softCntPc,   /* block_cov */
+                run->global->io.dynfileqCnt               /* corpus_count */
             );
         }
 

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -428,7 +428,7 @@ int main(int argc, char** argv) {
             PLOG_F("Couldn't open statsfile open('%s')", hfuzz.io.statsFileName);
         } else {
             dprintf(hfuzz.io.statsFileFd, "# unix_time, last_cov_update, total_exec, exec_per_sec, "
-                                          "crashes, unique_crashes, hangs, edge_cov, block_cov\n");
+                                          "crashes, unique_crashes, hangs, edge_cov, block_cov, corpus_count\n");
         }
     }
 


### PR DESCRIPTION
Adds the size of the dynamic corpus to the stats file. This metric is otherwise only output in the TTY output.