### PR TITLE
Add option for regular stats file updates

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -358,6 +358,8 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
                 .runEndTime             = 0,
                 .tmOut                  = 1,
                 .lastCovUpdate          = time(NULL),
+                .lastStatsUpdate        = 0,
+                .statsUpdateInterval    = 0,
                 .exitOnTime             = 0,
                 .timeOfLongestUnitUSecs = 0,
                 .tmoutVTALRM            = false,
@@ -533,6 +535,7 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
         { { "pin_thread_cpu", required_argument, NULL, 0x114 }, "Pin a single execution thread to this many consecutive CPUs (default: 0 = no CPU pinning)" },
         { { "dynamic_input", required_argument, NULL, 0x115 }, "Path to a directory containing the dynamic file corpus" },
         { { "statsfile", required_argument, NULL, 0x116 }, "Stats file" },
+        { { "statsfile_update_interval", required_argument, NULL, 0x117 }, "Maximum time interval (in seconds) for stats file updates (default: 0 = only update stats file on coverage increase)" },
 
 #if defined(_HF_ARCH_LINUX)
         { { "linux_symbols_bl", required_argument, NULL, 0x504 }, "Symbols blocklist filter file (one entry per line)" },
@@ -824,6 +827,13 @@ bool cmdlineParse(int argc, char* argv[], honggfuzz_t* hfuzz) {
             break;
         case 0x116:
             hfuzz->io.statsFileName = optarg;
+            break;
+        case 0x117:
+            if (!util_isANumber(optarg)) {
+                LOG_E("'-s %s' is not a number", optarg);
+                return false;
+            }
+            hfuzz->timing.statsUpdateInterval = strtoul(optarg, NULL, 0);
             break;
         default:
             cmdlineHelp(argv[0], custom_opts);

--- a/fuzz.c
+++ b/fuzz.c
@@ -219,9 +219,21 @@ static void fuzz_perfFeedback(run_t* run) {
     int64_t diff0 = (int64_t)run->global->feedback.hwCnts.cpuInstrCnt - run->hwCnts.cpuInstrCnt;
     int64_t diff1 = (int64_t)run->global->feedback.hwCnts.cpuBranchCnt - run->hwCnts.cpuBranchCnt;
 
-    /* Any increase in coverage (edge, pc, cmp, hw) counters forces adding input to the corpus */
-    if (run->hwCnts.newBBCnt > 0 || softNewPC > 0 || softNewEdge > 0 || softNewCmp > 0 ||
-        diff0 < 0 || diff1 < 0) {
+    /* Is there any increase in coverage (edge, pc, cmp, hw) counters? */
+    const bool isNewCoverage = run->hwCnts.newBBCnt > 0 || softNewPC > 0 || softNewEdge > 0 ||
+                               softNewCmp > 0 || diff0 < 0 || diff1 < 0;
+
+    if (!isNewCoverage && run->dynfile->imported) {
+        /* Remove useless imported inputs from corpus */
+        LOG_D("Removing useless imported file: %s", run->dynfile->path);
+        char fname[PATH_MAX];
+        snprintf(fname, PATH_MAX, "%s/%s",
+            run->global->io.outputDir ? run->global->io.outputDir : run->global->io.inputDir,
+            run->dynfile->path);
+        unlink(fname);
+    }
+
+    if (isNewCoverage) {
         if (diff0 < 0) {
             run->global->feedback.hwCnts.cpuInstrCnt = run->hwCnts.cpuInstrCnt;
         }
@@ -241,9 +253,16 @@ static void fuzz_perfFeedback(run_t* run) {
             softNewPC, softNewCmp, run->hwCnts.cpuInstrCnt, run->hwCnts.cpuBranchCnt,
             run->global->feedback.hwCnts.bbCnt, run->global->feedback.hwCnts.softCntEdge,
             run->global->feedback.hwCnts.softCntPc, run->global->feedback.hwCnts.softCntCmp);
+    }
 
+    const time_t curr_sec            = time(NULL);
+    const time_t lastStatsUpdate     = ATOMIC_GET(run->global->timing.lastStatsUpdate);
+    const time_t statsUpdateInterval = ATOMIC_GET(run->global->timing.statsUpdateInterval);
+    const bool   isStatsIntervalElapsed =
+        statsUpdateInterval > 0 && (curr_sec - lastStatsUpdate) >= statsUpdateInterval;
+
+    if (isNewCoverage || isStatsIntervalElapsed) {
         if (run->global->io.statsFileName) {
-            const time_t curr_sec      = time(NULL);
             const time_t elapsed_sec   = curr_sec - run->global->timing.timeStart;
             size_t       curr_exec_cnt = ATOMIC_GET(run->global->cnts.mutationsCnt);
             /*
@@ -271,8 +290,12 @@ static void fuzz_perfFeedback(run_t* run) {
                 run->global->feedback.hwCnts.softCntPc,   /* block_cov */
                 run->global->io.dynfileqCnt               /* corpus_count */
             );
+            ATOMIC_SET(run->global->timing.lastStatsUpdate, curr_sec);
         }
+    }
 
+    /* Add input to the corpus in case of any increase in coverage */
+    if (isNewCoverage) {
         /* Update per-input coverage metrics */
         run->dynfile->cov[0] = softCurEdge + softCurPC + run->hwCnts.bbCnt;
         run->dynfile->cov[1] = softCurCmp;
@@ -290,14 +313,6 @@ static void fuzz_perfFeedback(run_t* run) {
             LOG_D("SocketFuzzer: fuzz: new BB (perf)");
             fuzz_notifySocketFuzzerNewCov(run->global);
         }
-    } else if (run->dynfile->imported) {
-        /* Remove useless imported inputs from corpus */
-        LOG_D("Removing useless imported file: %s", run->dynfile->path);
-        char fname[PATH_MAX];
-        snprintf(fname, PATH_MAX, "%s/%s",
-            run->global->io.outputDir ? run->global->io.outputDir : run->global->io.inputDir,
-            run->dynfile->path);
-        unlink(fname);
     }
 }
 

--- a/honggfuzz.h
+++ b/honggfuzz.h
@@ -251,6 +251,8 @@ typedef struct {
         time_t  runEndTime;
         time_t  tmOut;
         time_t  lastCovUpdate;
+        time_t  lastStatsUpdate;
+        time_t  statsUpdateInterval;
         time_t  exitOnTime;
         int64_t timeOfLongestUnitUSecs;
         bool    tmoutVTALRM;


### PR DESCRIPTION
Honggfuzz updates the stats file only when an increase in coverage (edge, pc, cmp, hw) counters is observed. The stats file includes metrics such as `total_exec` and `exec_per_sec` that are interesting to observe regularly to programmatically monitor the progress of a fuzzing run when honggfuzz is run in a pipeline or from a tool that observes the stats file. This PR adds an option to specify an interval in seconds to update the stats file regardless of coverage increases. This is similar to the `AFL_FUZZER_STATS_UPDATE_INTERVAL` environment variable for AFL++.

More specifically, the responsible function `fuzz_perfFeedback` is adjusted as follows:
- If there is no coverage increase and the input is imported, then remove this useless input from the corpus
- If there is a coverage increase, log the progress line using `LOG_I(...)`
- If there is a coverage increase or the update interval has elapsed, update the stats file.
- Finally, if there is a coverage increase, add the input to the corpus and update the coverage metrics.