### PR TITLE
Fix linking of fuzz test on mac

### DIFF
--- a/hfuzz_cc/hfuzz-cc.c
+++ b/hfuzz_cc/hfuzz-cc.c
@@ -576,7 +576,7 @@ static int ldMode(int argc, char** argv) {
     /* Ensure to link libhfuzz to the fuzz test executable*/
     if (isExecutableBuild(argc, argv)) {
 #if defined(_HF_ARCH_DARWIN)
-        args[j++] = "-Wl,-all_load";
+        args[j++] = "-Wl,-force_load";
 #else
         args[j++] = "-Wl,--whole-archive";
 #endif


### PR DESCRIPTION
`-all_load` forces all libraries on the linker command line to included which causes problems when linking libhfnetdriver which also contains a `LLVMFuzzerTestOneInput` symbol. With `-force_load` only the libhfuzz library is linked retaining all symbols.